### PR TITLE
Bats test cleanup

### DIFF
--- a/scripts/assertions.bash
+++ b/scripts/assertions.bash
@@ -1,0 +1,53 @@
+# This file contains functions for making assertions about docker tag existence
+# both in the local daemon and in specific tarballs.
+
+tag_exists() {
+	docker inspect "$1" > /dev/null 2>&1  && return 0
+	return 1
+}
+
+assert_tag_exists_locally() {
+	tag_exists "$1" && return 0
+	echo "Assertion failed: tag $1 missing."
+	return 1
+}
+
+assert_tags_exist_locally() {
+	for T in "$@"; do
+		assert_tag_exists_locally "$T"
+	done
+}
+
+assert_tag_does_not_exist_locally() {
+	tag_exists "$1" || return 0
+	echo "Assertion failed: tag $1 exists, but it should not."
+	return 1
+}
+
+assert_tags_do_not_exist_locally() {
+	for T in "$@"; do
+		assert_tag_does_not_exist_locally "$T"
+	done
+}
+
+remove_tags() { docker rmi "$@" > /dev/null 2>&1 || true; }
+
+tarball_tag_check_prep() { TARBALL="$1"; shift
+	[ -f "$TARBALL" ] || {
+		echo "Tarball not found: $TARBALL"
+		return 1
+	}
+	remove_tags "$@"
+	assert_tags_do_not_exist_locally "$@"
+	docker load -i "$TARBALL"
+}
+
+assert_tarball_contains_tags() { TARBALL="$1"; shift
+	tarball_tag_check_prep "$TARBALL" "$@"
+	assert_tags_exist_locally "$@"
+}
+
+assert_tarball_not_contains_tags() { TARBALL="$1"; shift
+	tarball_tag_check_prep "$TARBALL" "$@"
+	assert_tags_do_not_exist_locally "$@"
+}

--- a/scripts/assertions.bash.bats
+++ b/scripts/assertions.bash.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+load assertions
+
+BLANK_TAG="actions-docker-build/test:_blank"
+WORKDIR="testdata/assertions/.tmp"
+
+build_blank_image() {
+	# This image isn't completely blank because completely blank images
+	# aren't able to be exported via 'docker save', so we just copy in
+	# whatever's in the WORKDIR to get around this.
+	docker build -t "$BLANK_TAG" -f - . <<< "
+		FROM scratch
+		COPY * ./
+	"
+}
+
+make_blank_workdir() {
+	rm -rf "$WORKDIR"
+	mkdir -p "$WORKDIR"
+	cd "$WORKDIR"
+	echo "*" > ".gitignore"
+}
+
+setup() {
+	make_blank_workdir
+	build_blank_image
+}
+
+@test assert_tag_exists_locally() {
+	assert_tag_exists_locally "$BLANK_TAG"
+	docker rmi "$BLANK_TAG"
+	if assert_tag_exists_locally "$BLANK_TAG"; then
+		echo "Failed: deleted tag detected as existing."
+	fi
+}
+
+@test assert_tags_exist_locally() {
+	assert_tags_exist_locally "$BLANK_TAG"
+	docker rmi "$BLANK_TAG"
+	if assert_tags_exist_locally "$BLANK_TAG"; then
+		echo "Failed: deleted tag detected as existing."
+	fi
+}
+
+@test assert_tag_does_not_exist_locally() {
+	if assert_tag_does_not_exist_locally "$BLANK_TAG"; then
+		echo "Failed: existing tag detected as not existing."
+	fi	
+	docker rmi "$BLANK_TAG"
+	assert_tag_does_not_exist_locally "$BLANK_TAG"
+}
+
+@test assert_tags_do_not_exist_locally() {
+	if assert_tags_do_not_exist_locally "$BLANK_TAG"; then
+		echo "Failed: existing tag detected as not existing."
+	fi	
+	docker rmi "$BLANK_TAG"
+	assert_tag_does_not_exist_locally "$BLANK_TAG"
+}
+
+@test assert_tarball_contains_tags() {
+	local TAGS=("${BLANK_TAG}_1" "${BLANK_TAG}_2" "${BLANK_TAG}_3")
+	for T in "${TAGS[@]}"; do
+		docker tag "$BLANK_TAG" "$T"
+	done
+
+	local TARBALL="tarball.tar"
+
+	docker save -o "$TARBALL" "${TAGS[@]}"
+
+	NONEXISTENT="this/tag/is/not/in/the/tarball:latest"
+
+	# Assert checking all the tags are there at once works.
+	assert_tarball_contains_tags "$TARBALL" "${TAGS[@]}"	
+	
+	# Assert each separate tag is there.
+	assert_tarball_contains_tags "$TARBALL" "${TAGS[0]}"
+	assert_tarball_contains_tags "$TARBALL" "${TAGS[1]}"	
+	assert_tarball_contains_tags "$TARBALL" "${TAGS[2]}"
+
+	# Assert failure when only provided tag doesn't exist.
+	if assert_tarball_contains_tags "$TARBALL" "$NONEXISTENT"; then
+		echo "Failed: assert_tarball_contains_tags reported tag exists that doesn't"
+		return 1
+	fi
+
+	# Assert failure when one of the provided tags doesn't exist.
+	if assert_tarball_contains_tags "$TARBALL" "${TAGS[@]}" "$NONEXISTENT"; then
+		echo "Failed: assert_tarball_contains_tags reported tag exists that doesn't"
+		return 1
+	fi
+}

--- a/scripts/digest_inputs.bats
+++ b/scripts/digest_inputs.bats
@@ -1,3 +1,4 @@
+#!/usr/bin/env bats
 
 # setup ensures that there's a fresh .tmp directory, gitignored,
 # and sets the GITHUB_ENV variable to a file path inside that directory.

--- a/scripts/docker_build.bats
+++ b/scripts/docker_build.bats
@@ -35,16 +35,6 @@ set_all_env_vars() {
 	set_all_optional_env_vars
 }
 
-set_expected_tags() {
-	read -ra EXPECTED_TAGS <<< "$TAGS"
-	EXPECTED_TAGS+=("$AUTO_TAG")	
-}
-
-each_expected_tag() {
-	set_expected_tags
-	for TAG in "${EXPECTED_TAGS[@]}"; do $@ "$TAG"; done
-}
-
 tag_exists() {
 	docker inspect "$1" > /dev/null 2>&1  && return 0
 	return 1
@@ -74,15 +64,6 @@ assert_tags_do_not_exist_locally() {
 	done
 }
 
-assert_expected_tags_do_not_exist() { each_expected_tag assert_tag_does_not_exist_locally; }
-
-assert_expected_tags_exist() { each_expected_tag assert_tag_exists_locally; }
-
-remove_expected_tags() {
-	each_expected_tag remove_tags
-	each_expected_tag assert_tag_does_not_exist_locally
-}
-
 remove_tags() { docker rmi "$@" > /dev/null 2>&1 || true; }
 
 assert_tags_exist() {
@@ -98,7 +79,6 @@ tarball_tag_check_prep() { TARBAL="$1"; shift
 	assert_tags_do_not_exist_locally "$@"
 	docker load -i "$TARBALL"
 }
-	
 
 assert_tarball_contains_tags() { TARBALL="$1"; shift
 	tarball_tag_check_prep "$TARBALL" "$@"

--- a/scripts/docker_build.bats
+++ b/scripts/docker_build.bats
@@ -1,3 +1,7 @@
+#!/usr/bin/env bats
+
+load assertions
+
 setup() {
 	set_all_env_vars
 
@@ -35,60 +39,6 @@ set_all_env_vars() {
 	set_all_optional_env_vars
 }
 
-tag_exists() {
-	docker inspect "$1" > /dev/null 2>&1  && return 0
-	return 1
-}
-
-assert_tag_exists_locally() {
-	tag_exists "$1" && return 0
-	echo "Assertion failed: tag $1 missing."
-	return 1
-}
-
-assert_tags_exist_locally() {
-	for T in "$@"; do
-		assert_tag_exists_locally "$T"
-	done
-}
-
-assert_tag_does_not_exist_locally() {
-	tag_exists "$1" || return 0
-	echo "Assertion failed: tag $1 exists, but it should not."
-	return 1
-}
-
-assert_tags_do_not_exist_locally() {
-	for T in "$@"; do
-		assert_tag_does_not_exist_locally "$T"
-	done
-}
-
-remove_tags() { docker rmi "$@" > /dev/null 2>&1 || true; }
-
-assert_tags_exist() {
-	for TAG in "$@"; do assert_tag_exists_locally "$TAG"; done
-}
-
-tarball_tag_check_prep() { TARBAL="$1"; shift
-	[ -f "$TARBALL" ] || {
-		echo "Tarball not found: $TARBALL"
-		return 1
-	}
-	remove_tags "$@"
-	assert_tags_do_not_exist_locally "$@"
-	docker load -i "$TARBALL"
-}
-
-assert_tarball_contains_tags() { TARBALL="$1"; shift
-	tarball_tag_check_prep "$TARBALL" "$@"
-	assert_tags_exist_locally "$@"
-}
-
-assert_tarball_not_contains_tags() { TARBALL="$1"; shift
-	tarball_tag_check_prep "$TARBALL" "$@"
-	assert_tags_do_not_exist_locally "$@"
-}
 
 set_test_prod_tags() {
 	PROD_TAG1=dadgarcorp/repo1:1.2.3


### PR DESCRIPTION
Tidies up some loose ends in the bats tests, extracts the assertions into their own files, and adds some tests around the assertions themselves. Asserting that tarballs contain certain docker tags isn't entirely trivial so it's worth being sure we're doing that right.

Also makes the bats test files executable so you can run them directly with e.g. `cd scripts && ./docker_build.bats`