### PR TITLE
Add support for optional repo name input

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -70,17 +70,18 @@ jobs:
         # For real usages, you will reference the action like this:
         # 'uses: hashicorp/actions-docker-build@v1'
         with:
+          repo: ${{ env.product_name }}
           version: 1.0.0
           target: default
           arch: ${{ matrix.arch }}
           # Production tags. (These are the tags used for the multi-arch images
           # we eventually push, they must never be architecture/platform-specific.)
           tags: |
-            docker.io/hashicorp/${{env.product_name}}:${{env.version}}
-            public.ecr.aws/hashicorp/${{env.product_name}}:${{env.version}}
+            docker.io/hashicorp/${{ env.product_name }}:${{ env.version }}
+            public.ecr.aws/hashicorp/${{ env.product_name }}:${{ env.version }}
           # Dev tags are pushed more frequently by downstream processes. They also
           # must not reference the architecture.
           dev_tags: |
-            docker.io/hashicorp/${{env.product_name}}:${{env.version}}-dev
+            docker.io/hashicorp/${{ env.product_name }}:${{ env.version }}-dev
           # Usually you wouldn't need to set workdir, but this is just an example.
           workdir: example/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,8 @@
 name: test
 on: [push]
 
-env:
+env:  
+  REPO: actions-docker-build
   TAG_PREFIX: artifactory.hashicorp.engineering/actions-docker-build/test
 
 jobs:
@@ -54,6 +55,7 @@ jobs:
       - name: Invoke Action
         uses: ./ # This is the action we're testing.
         with:
+          repo: ${{ env.REPO }}
           version: 1.0.0
           target: default
           arch: amd64
@@ -81,6 +83,7 @@ jobs:
       - name: Invoke Action
         uses: ./ # This is the action we're testing.
         with:
+          repo: ${{ env.REPO }}
           version: 1.0.0
           target: default
           arch: amd64
@@ -109,6 +112,7 @@ jobs:
       - name: Invoke Action
         uses: ./ # This is the action we're testing.
         with:
+          repo: ${{ env.REPO }}
           version: 1.0.0
           target: default
           arch: amd64
@@ -137,6 +141,7 @@ jobs:
       - name: Invoke Action
         uses: ./
         with:
+          repo: ${{ env.REPO }}
           version: 1.0.0
           target: default
           arch: amd64
@@ -163,6 +168,7 @@ jobs:
         id: docker-build
         uses: ./
         with:
+          repo: ${{ env.REPO }}
           version: 1.0.0
           target: default
           arch: amd64

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ you must call it multiple times in order to build multiple architectures.
 
 ### Action Inputs Explained
 
+- **`repo`** is the name of the repository where the Dockerfile is defined.
 - **`version`** is the product version we are building a docker image for.
 - **`target`** is the name of the "stage" or "target" in the Dockerfile to build.
 - **`arch`** is the architecture we're building for.

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ description: Builds and stores Docker images.
 inputs:
 
   # Required explicit inputs.
+  repo:
+    description: Name of the GitHub repository, e.g. "vault-enterprise" or "consul".
+    required: true
+
   version:
     description: Version of the product, e.g. "X.Y.Z[-pre][+edition]".
     required: true
@@ -89,22 +93,22 @@ runs:
       env:
 
         # Required.
-        REPO_NAME: "${{github.event.repository.name}}"
-        REVISION: "${{github.sha}}"
-        VERSION: "${{inputs.version}}"
-        ARCH: "${{inputs.arch}}"
-        TAGS: "${{inputs.tags}}"
-        TARGET: "${{inputs.target}}"
+        REPO_NAME: "${{ inputs.repo }}"
+        REVISION: "${{ github.sha }}"
+        VERSION: "${{ inputs.version }}"
+        ARCH: "${{ inputs.arch }}"
+        TAGS: "${{ inputs.tags }}"
+        TARGET: "${{ inputs.target }}"
 
         # Optional.
-        DEV_TAGS: "${{inputs.dev_tags}}"
-        ARM_VERSION: "${{inputs.arm_version}}"
-        PKG_NAME: "${{inputs.pkg_name}}"
-        WORKDIR: "${{inputs.workdir}}"
-        ZIP_NAME: "${{inputs.zip_artifact_name}}"
-        BIN_NAME: "${{inputs.bin_name}}"
+        DEV_TAGS: "${{ inputs.dev_tags }}"
+        ARM_VERSION: "${{ inputs.arm_version }}"
+        PKG_NAME: "${{ inputs.pkg_name }}"
+        WORKDIR: "${{ inputs.workdir }}"
+        ZIP_NAME: "${{ inputs.zip_artifact_name }}"
+        BIN_NAME: "${{ inputs.bin_name }}"
 
-        DOCKERFILE: "${{inputs.dockerfile}}"
+        DOCKERFILE: "${{ inputs.dockerfile }}"
 
       run: ${{ github.action_path }}/scripts/digest_inputs 
 
@@ -115,8 +119,8 @@ runs:
     - name: Download Product Zip Artifact
       uses: actions/download-artifact@v2
       with:
-        name: ${{env.ZIP_NAME}}
-        path: ${{env.ZIP_LOCATION}}
+        name: ${{ env.ZIP_NAME }}
+        path: ${{ env.ZIP_LOCATION }}
 
     - name: Extract Product Zip Artifact
       shell: bash
@@ -127,23 +131,23 @@ runs:
       run: ${{ github.action_path}}/scripts/docker_build
     
     - name: Run Test
-      if: ${{env.PLATFORM == 'linux/amd64' && inputs.smoke_test != ''}}
+      if: ${{ env.PLATFORM == 'linux/amd64' && inputs.smoke_test != '' }}
       shell: bash
       run: ${{ inputs.smoke_test }}
       env:
-        IMAGE_NAME: ${{env.AUTO_TAG}}
+        IMAGE_NAME: ${{ env.AUTO_TAG }}
 
     - name: Upload Prod Tarball
       uses: actions/upload-artifact@v2
       with:
-        name: ${{env.TARBALL_NAME}}
-        path: ${{env.TARBALL_NAME}}
+        name: ${{ env.TARBALL_NAME }}
+        path: ${{ env.TARBALL_NAME }}
         if-no-files-found: error
 
     - name: Upload Dev Tarball
       uses: actions/upload-artifact@v2
-      if: ${{env.DEV_TAGS != ''}}
+      if: ${{ env.DEV_TAGS != '' }}
       with:
-        name: ${{env.DEV_TARBALL_NAME}}
-        path: ${{env.DEV_TARBALL_NAME}}
+        name: ${{ env.DEV_TARBALL_NAME }}
+        path: ${{ env.DEV_TARBALL_NAME }}
         if-no-files-found: error

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,6 @@ description: Builds and stores Docker images.
 inputs:
 
   # Required explicit inputs.
-  repo:
-    description: Name of the GitHub repository, e.g. "vault-enterprise" or "consul".
-    required: true
-
   version:
     description: Version of the product, e.g. "X.Y.Z[-pre][+edition]".
     required: true
@@ -24,6 +20,10 @@ inputs:
     required: true
 
   # General purpose inputs.
+  repo:
+    description: Name of the GitHub repository, e.g. "vault-enterprise" or "consul".
+    required: false
+    
   target:
     description: >
       Dockerfile target stage to build.
@@ -88,12 +88,19 @@ runs:
   #  DOCKER_BUILDKIT: 1
   #  BUILDKIT_PROGRESS: plain
   steps:
+    - name: Set repo name env var
+      shell: bash
+      run: |
+          if [[ "${{ inputs.repo }}" == "" ]]; then
+              echo "REPO_NAME=${{github.event.repository.name}}" >> "$GITHUB_ENV"
+          else
+              echo "REPO_NAME=${{ inputs.repo }}" >> "$GITHUB_ENV"
+          fi
     - name: Digest Inputs - Calculate Variables for Later Steps
       shell: bash
       env:
 
         # Required.
-        REPO_NAME: "${{ inputs.repo }}"
         REVISION: "${{ github.sha }}"
         VERSION: "${{ inputs.version }}"
         ARCH: "${{ inputs.arch }}"


### PR DESCRIPTION
### Justification

Related github issue: https://github.com/hashicorp/actions-docker-build/issues/16
Slack thread about the github issue: https://hashicorp.slack.com/archives/C024ZDP4YGY/p1646325360323529

### Summary

This makes `repo` an optional input to the github action, since `github.event.repository.name` is not set when the build workflow is called from the `workflow_call` event. Note that this is not a breaking change as `github.event.repository.name` is set in the majority of cases. We'll use that if `repo` is not set as an input. 

### Quality

I updated the existing test workflows and the readme. Let me know if there's anything else required. 