### PR TITLE
Use github.repository to extract repo name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,12 +84,9 @@ runs:
   #  DOCKER_BUILDKIT: 1
   #  BUILDKIT_PROGRESS: plain
   steps:
-    - name: Test repo name...
-      shell: bash
-      run: echo ${{ github.repository }} | cut -f1 -d "/"
     - name: Set required repo name env var
       shell: bash
-      run: echo "REPO_NAME=$(echo ${{ github.repository }} | cut -f1 -d "/")" >> $GITHUB_ENV
+      run: echo "REPO_NAME=$(echo ${{ github.repository }} | cut -f2 -d "/")" >> $GITHUB_ENV
 
     - name: Digest Inputs - Calculate Variables for Later Steps
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -84,12 +84,15 @@ runs:
   #  DOCKER_BUILDKIT: 1
   #  BUILDKIT_PROGRESS: plain
   steps:
+    - name: Set required repo name env var
+      shell: bash
+      run: echo "REPO_NAME=$(echo ${{ github.repository }} | cut -f1 -d "/")" >> $GITHUB_ENV
+
     - name: Digest Inputs - Calculate Variables for Later Steps
       shell: bash
       env:
 
         # Required.
-        REPO_NAME: "${{github.event.repository.name}}"
         REVISION: "${{github.sha}}"
         VERSION: "${{inputs.version}}"
         ARCH: "${{inputs.arch}}"

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
   steps:
     - name: Test repo name...
       shell: bash
-      run: echo ${{ github.repository }} | cut -f1 -d "/")
+      run: echo ${{ github.repository }} | cut -f1 -d "/"
     - name: Set required repo name env var
       shell: bash
       run: echo "REPO_NAME=$(echo ${{ github.repository }} | cut -f1 -d "/")" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: docker-build
-author: Release Engineering <team-rel-eng@hashicorp.com>
+author: Release Engineering <rel-eng@hashicorp.com>
 description: Builds and stores Docker images.
 
 inputs:
@@ -93,21 +93,21 @@ runs:
       env:
 
         # Required.
-        REVISION: "${{github.sha}}"
-        VERSION: "${{inputs.version}}"
-        ARCH: "${{inputs.arch}}"
-        TAGS: "${{inputs.tags}}"
-        TARGET: "${{inputs.target}}"
+        REVISION: "${{ github.sha }}"
+        VERSION: "${{ inputs.version }}"
+        ARCH: "${{ inputs.arch }}"
+        TAGS: "${{ inputs.tags }}"
+        TARGET: "${{ inputs.target }}"
 
         # Optional.
-        DEV_TAGS: "${{inputs.dev_tags}}"
-        ARM_VERSION: "${{inputs.arm_version}}"
-        PKG_NAME: "${{inputs.pkg_name}}"
-        WORKDIR: "${{inputs.workdir}}"
-        ZIP_NAME: "${{inputs.zip_artifact_name}}"
-        BIN_NAME: "${{inputs.bin_name}}"
+        DEV_TAGS: "${{ inputs.dev_tags }}"
+        ARM_VERSION: "${{ inputs.arm_version }}"
+        PKG_NAME: "${{ inputs.pkg_name }}"
+        WORKDIR: "${{ inputs.workdir }}"
+        ZIP_NAME: "${{ inputs.zip_artifact_name }}"
+        BIN_NAME: "${{ inputs.bin_name }}"
 
-        DOCKERFILE: "${{inputs.dockerfile}}"
+        DOCKERFILE: "${{ inputs.dockerfile }}"
 
       run: ${{ github.action_path }}/scripts/digest_inputs 
 
@@ -118,8 +118,8 @@ runs:
     - name: Download Product Zip Artifact
       uses: actions/download-artifact@v2
       with:
-        name: ${{env.ZIP_NAME}}
-        path: ${{env.ZIP_LOCATION}}
+        name: ${{ env.ZIP_NAME }}
+        path: ${{ env.ZIP_LOCATION }}
 
     - name: Extract Product Zip Artifact
       shell: bash
@@ -130,7 +130,7 @@ runs:
       run: ${{ github.action_path}}/scripts/docker_build
     
     - name: Run Test
-      if: ${{env.PLATFORM == 'linux/amd64' && inputs.smoke_test != ''}}
+      if: ${{ env.PLATFORM == 'linux/amd64' && inputs.smoke_test != '' }}
       shell: bash
       run: ${{ inputs.smoke_test }}
       env:
@@ -139,14 +139,14 @@ runs:
     - name: Upload Prod Tarball
       uses: actions/upload-artifact@v2
       with:
-        name: ${{env.TARBALL_NAME}}
-        path: ${{env.TARBALL_NAME}}
+        name: ${{ env.TARBALL_NAME }}
+        path: ${{ env.TARBALL_NAME }}
         if-no-files-found: error
 
     - name: Upload Dev Tarball
       uses: actions/upload-artifact@v2
-      if: ${{env.DEV_TAGS != ''}}
+      if: ${{ env.DEV_TAGS != '' }}
       with:
-        name: ${{env.DEV_TARBALL_NAME}}
-        path: ${{env.DEV_TARBALL_NAME}}
+        name: ${{ env.DEV_TARBALL_NAME }}
+        path: ${{ env.DEV_TARBALL_NAME }}
         if-no-files-found: error

--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,9 @@ runs:
   #  DOCKER_BUILDKIT: 1
   #  BUILDKIT_PROGRESS: plain
   steps:
+    - name: Test repo name...
+      shell: bash
+      run: echo ${{ github.repository }} | cut -f1 -d "/")
     - name: Set required repo name env var
       shell: bash
       run: echo "REPO_NAME=$(echo ${{ github.repository }} | cut -f1 -d "/")" >> $GITHUB_ENV


### PR DESCRIPTION
### Justification

Related github issue: https://github.com/hashicorp/actions-docker-build/issues/16
Slack thread about the github issue: https://hashicorp.slack.com/archives/C024ZDP4YGY/p1646325360323529
Suggestion from Sam to use github.repository: https://github.com/hashicorp/actions-docker-build/pull/17#pullrequestreview-901650073

### Summary

This sets `REPO_NAME` as an env var using the `github.repository` context instead of the `github.event.repository.name` context, which cannot be set when the `build` workflow is called from the `workflow_call` event. 

### Quality

I ran a minimized test to ensure this value is being set properly in scheduled jobs on a fork of packer. Here is the action that ran: https://github.com/mdeggies/packer-1/runs/5452739537?check_suite_focus=true and produced the right result. 
