### PR TITLE
handle enterprise versions correctly

### DIFF
--- a/scripts/digest_inputs
+++ b/scripts/digest_inputs
@@ -6,9 +6,8 @@
 
 set -Eeuo pipefail
 
-# shellcheck disable=SC1091
-VALIDATION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
-source "${VALIDATION_DIR}/validation.bash"
+# shellcheck source=scripts/validation.bash
+source "${BASH_SOURCE%/*}/validation.bash"
 
 die() { echo "$1" 1>&2; exit 1; }
 
@@ -62,7 +61,9 @@ ENT_META=""
 # If it did, then we've detected a likely enterprise repo.
 [ "$REPO_NAME" != "$REPO_NAME_MINUS_ENTERPRISE" ] && {
   ENTERPRISE_DETECTED=true
-  ENT_META="+ent"
+  if ! [[ "$VERSION" =~ .*\+.* ]]; then
+  	ENT_META="+ent"
+  fi
 }
 
 add_vars REPO_NAME REPO_NAME_MINUS_ENTERPRISE ENTERPRISE_DETECTED


### PR DESCRIPTION
### Justification

When the version string contains a `+` e.g. `+ent` or `+ent-fips` we should just use that and not append another `+ent`.

### Summary

We now respect the full version string provided.

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [x] New or updated tests which validate the new behavior.  _(Thank you!)_