### PR TITLE
Enterprise version handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
           BATS_REPO: https://github.com/bats-core/bats-core
           BATS_PATH: /usr/local/bats
         run: |
-          sudo git clone --depth 1 --branch v$BATS_VERSION $BATS_REPO $BATS_PATH
-          echo $BATS_PATH/bin >> $GITHUB_PATH
+          sudo git clone --depth 1 --branch "v$BATS_VERSION" "$BATS_REPO" "$BATS_PATH"
+          echo "$BATS_PATH/bin" >> "$GITHUB_PATH"
       - uses: actions/checkout@v2
       - name: Run BATS tests
         run: make test

--- a/scripts/digest_inputs
+++ b/scripts/digest_inputs
@@ -6,10 +6,11 @@
 
 set -Eeuo pipefail
 
+# shellcheck source=scripts/logging.bash
+source "${BASH_SOURCE%/*}/logging.bash"
+
 # shellcheck source=scripts/validation.bash
 source "${BASH_SOURCE%/*}/validation.bash"
-
-die() { echo "$1" 1>&2; exit 1; }
 
 # Required env vars.
 [ -n "${GITHUB_ENV:-}" ] || die "Must set GITHUB_ENV"
@@ -54,22 +55,39 @@ add_vars TAGS REDHAT_TAG DEV_TAGS WORKDIR DOCKERFILE
 
 # Determine repo name values.
 REPO_NAME_MINUS_ENTERPRISE="${REPO_NAME%%-enterprise}"
+
 # Assume this is not enterprise.
 ENTERPRISE_DETECTED=false
-ENT_META=""
+
+#
+## Version mangling.
+#
+# Catch and auto-correct a few common mistakes with the version input.
+# Emit loud warnings when action is taken based on these rules.
+
 # This checks if removing '-enterprise' suffix actually did anything.
 # If it did, then we've detected a likely enterprise repo.
 [ "$REPO_NAME" != "$REPO_NAME_MINUS_ENTERPRISE" ] && {
   ENTERPRISE_DETECTED=true
   # If the version doesn't contain a '+' or '-ent' then add the '+ent' suffix.
   if [[ ! "$VERSION" =~ .*\+.* ]] && [[ ! "$VERSION" =~ .*-ent.* ]]; then
-	VERSION="$VERSION+ent"
+	NEW_VERSION="$VERSION+ent"
+    warn "Appending '+ent' to the version string '$VERSION' -> '$NEW_VERSION' add '+ent' to the version input to remove this warning."
+	VERSION="$NEW_VERSION"
   fi
 }
 
 # If the version contains '-ent' then rectify this to '+ent' for the sake
 # getting the correct default zip name for the product.
-VERSION="${VERSION//-ent/+ent}"
+if [[ "$VERSION" =~ .*-ent.* ]]; then
+	NEW_VERSION="${VERSION//-ent/+ent}"
+	warn "Changing '-ent' to '+ent' in version string; '$VERSION' -> '$NEW_VERSION'; change the version input to '$NEW_VERSION' to remove this warning."
+	VERSION="$NEW_VERSION"
+fi
+
+#
+## End version mangling.
+#
 
 add_vars REPO_NAME REPO_NAME_MINUS_ENTERPRISE ENTERPRISE_DETECTED
 

--- a/scripts/digest_inputs
+++ b/scripts/digest_inputs
@@ -33,6 +33,18 @@ DOCKERFILE="${DOCKERFILE:-Dockerfile}"
 TAGS="${TAGS:-}"
 REDHAT_TAG="${REDHAT_TAG:-}"
 
+autocorrect_tags() {
+	local NEW_TAGS
+	trap 'echo "$NEW_TAGS"' RETURN
+	NEW_TAGS="$(tr + - <<< "$2")"
+	[[ "$NEW_TAGS" = "$TAGS" ]] || warn "Input '$1' contains '+' character(s), replacing them with '-'."
+}
+
+# Autocorrect tags.
+TAGS="$(autocorrect_tags       tags       "$TAGS")"
+DEV_TAGS="$(autocorrect_tags   dev_tags   "$DEV_TAGS")"
+REDHAT_TAG="$(autocorrect_tags redhat_tag "$REDHAT_TAG")"
+
 # Validate tags.
 tags_validation "$TAGS"
 redhat_tag_validation "$REDHAT_TAG"

--- a/scripts/digest_inputs
+++ b/scripts/digest_inputs
@@ -61,10 +61,15 @@ ENT_META=""
 # If it did, then we've detected a likely enterprise repo.
 [ "$REPO_NAME" != "$REPO_NAME_MINUS_ENTERPRISE" ] && {
   ENTERPRISE_DETECTED=true
-  if ! [[ "$VERSION" =~ .*\+.* ]]; then
+  # If the version doesn't contain a '+' or '-ent' then add the '+ent' suffix.
+  if [[ ! "$VERSION" =~ .*\+.* ]] && [[ ! "$VERSION" =~ .*-ent.* ]]; then
 	VERSION="$VERSION+ent"
   fi
 }
+
+# If the version contains '-ent' then rectify this to '+ent' for the sake
+# getting the correct default zip name for the product.
+VERSION="${VERSION//-ent/+ent}"
 
 add_vars REPO_NAME REPO_NAME_MINUS_ENTERPRISE ENTERPRISE_DETECTED
 

--- a/scripts/digest_inputs.bats
+++ b/scripts/digest_inputs.bats
@@ -67,12 +67,28 @@ assert_exported_in_github_env() {
 	'
 }
 
-@test "ent version provided / handled correctly" {
+@test "ent version +ent provided / handled correctly" {
 
 	set_all_required_env_vars_and_tags
 
 	REPO_NAME="repo1-enterprise"
 	VERSION="1.2.3+ent"
+
+	# Execute the script under test: digest_inputs
+	./digest_inputs
+
+	# Set the expected exported values of the required variables.
+	assert_exported_in_github_env VERSION   "1.2.3+ent"
+	assert_exported_in_github_env PKG_NAME  "repo1_1.2.3+ent"
+	assert_exported_in_github_env AUTO_TAG  "repo1-enterprise/default/linux/amd64:1.2.3-ent_cabba9e"
+}
+
+@test "ent version -ent provided / handled correctly" {
+
+	set_all_required_env_vars_and_tags
+
+	REPO_NAME="repo1-enterprise"
+	VERSION="1.2.3-ent"
 
 	# Execute the script under test: digest_inputs
 	./digest_inputs

--- a/scripts/digest_inputs.bats
+++ b/scripts/digest_inputs.bats
@@ -131,6 +131,57 @@ assert_exported_in_github_env() {
 	assert_exported_in_github_env AUTO_TAG  "repo1-enterprise/default/linux/amd64:1.2.3-ent-complex.version123_cabba9e"
 }
 
+@test "one tag contains a + character" {
+	set_all_required_env_vars_and_tags
+
+	export TAGS='
+		dadgarcorp/repo1:1.2.3+ent
+		public.ecr.aws/dadgarcorp/repo1:1.2.3-ent
+	'
+
+	# Execute the script under test: digest_inputs
+	./digest_inputs
+
+	assert_exported_in_github_env TAGS '
+		dadgarcorp/repo1:1.2.3-ent
+		public.ecr.aws/dadgarcorp/repo1:1.2.3-ent
+	'
+}
+
+@test "another tag contains a + character" {
+	set_all_required_env_vars_and_tags
+
+	export TAGS='
+		dadgarcorp/repo1:1.2.3-ent
+		public.ecr.aws/dadgarcorp/repo1:1.2.3+ent
+	'
+
+	# Execute the script under test: digest_inputs
+	./digest_inputs
+
+	assert_exported_in_github_env TAGS '
+		dadgarcorp/repo1:1.2.3-ent
+		public.ecr.aws/dadgarcorp/repo1:1.2.3-ent
+	'
+}
+
+@test "all tags contain + characters" {
+	set_all_required_env_vars_and_tags
+
+	export TAGS='
+		dadgarcorp/repo1:1.2.3+ent
+		public.ecr.aws/dadgarcorp/repo1:1.2.3+ent
+	'
+
+	# Execute the script under test: digest_inputs
+	./digest_inputs
+
+	assert_exported_in_github_env TAGS '
+		dadgarcorp/repo1:1.2.3-ent
+		public.ecr.aws/dadgarcorp/repo1:1.2.3-ent
+	'
+}
+
 @test "only required env vars and tags set - optional variables set as expected" {
 	set_all_required_env_vars_and_tags
 

--- a/scripts/logging.bash
+++ b/scripts/logging.bash
@@ -1,0 +1,36 @@
+log()  { echo "==> $*" 1>&2; }
+info() { log "$(bold_green "INFO: "   ) $(bold "$*")"; } 
+warn() { log "$(bold_red   "WARNING: ") $(bold "$*")"; }
+err()  { log "$(bold_red   "ERROR: "  ) $(bold "$*")"; return 1; }
+die()  { log "$(bold_red   "FATAL: "  ) $(bold "$*")"; exit 1; }
+
+styled_text() { ATTR="$1"; shift; echo -en '\033['"${ATTR}m$*"'\033[0m'; }
+
+bold()       { styled_text "1"    "$*"; }
+blue()       { styled_text "94"   "$*"; }
+bold_blue()  { styled_text "1;94" "$*"; }
+red()        { styled_text "91"   "$*"; }
+bold_red()   { styled_text "1;91" "$*"; }
+bold_green() { styled_text "1;92" "$*"; }
+
+log_bold() { log "$(bold_blue "$*")"; }
+
+# should_emit_gha_workflow_commands checks if we're running in GitHub
+# and that we're not running in a BATS test. We only want to emit these
+# commands outside of BATS tests in GitHub Actions, otherwise they
+# pollute stdout, adding noise and breaking some tests.
+should_emit_gha_workflow_commands() {
+	[ "${GITHUB_ACTIONS:-}" != "true" ] && [ -z "${BATS_TEST_NAME:-}" ]
+}
+
+# group_start begins a GitHub Actions log group.
+group_start() {
+	should_emit_gha_workflow_commands || return 0
+	echo "::group::$(bold "$*")"
+}
+
+# group_end begins a GitHub Actions log group.
+group_end() {
+	should_emit_gha_workflow_commands || return 0
+	echo "::endgroup::"
+}


### PR DESCRIPTION
### Justification

See [this slack thread](https://hashicorp.slack.com/archives/C01BWLSMJ03/p1655401686187909).

### Summary

This handles the cases where:
- We supply a version containing `-ent` to the `version` input. (That input is used to find the relevant zip file containing a product binary, not for the docker tag.)
  - If `version` contains `-ent` we now change it back to `+ent`,
  - We do this before the code that auto-appends `+ent` when it is missing, and emit a warning that this has been done.
- We supply a _tag_ containing a `+` (e.g. `+ent`)
  - We autocorrect this to `-` and warn.

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [x] New or updated tests which validate the new behavior.  _(Thank you!)_