### PR TITLE
[RELENG-20] validate version label is set in built image

### DIFF
--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -74,6 +74,20 @@ docker buildx build --load \
   -f "$DOCKERFILE" \
   .
 
+# validate version label is set to the correct value
+version_label_validation() {
+	val=$(docker inspect --format='{{ index .Config.Labels "version" }}' "${2}")
+	if [ "$val" = "" ]; then
+		die "Error: 'version' label must be set to version passed in but was empty"
+	elif [ "$val" != "${1}" ]; then
+		die "Error: 'version' label must be set to version passed in but was ($val)"
+	fi
+}
+
+for T in "${ALL_TAGS[@]}"; do
+	version_label_validation "$VERSION" "$T"
+done
+
 echo "==> Saving prod tags in '$TARBALL_PATH'"
 
 docker save --output "$TARBALL_PATH" "${PROD_TAGS_A[@]}" "$AUTO_TAG"

--- a/scripts/docker_build.bats
+++ b/scripts/docker_build.bats
@@ -122,3 +122,22 @@ exercise_docker_build_script() {
 	exercise_docker_build_script
 	assert_tarball_contains_tags "$REDHAT_TARBALL_PATH" "$REDHAT_TAG1"
 }
+
+@test "version label set to correct value" {
+	set_test_prod_tags
+	exercise_docker_build_script
+}
+
+@test "build with version label set to wrong value" {
+	set_test_prod_tags
+	export DOCKERFILE=version_label_incorrect_value.Dockerfile
+	run exercise_docker_build_script
+	[ $status -eq 1 ]
+}
+
+@test "build with version label unset" {
+	set_test_prod_tags
+	export DOCKERFILE=version_label_unset.Dockerfile
+	run exercise_docker_build_script
+	[ $status -eq 1 ]
+}

--- a/scripts/testdata/input/version_label_incorrect_value.Dockerfile
+++ b/scripts/testdata/input/version_label_incorrect_value.Dockerfile
@@ -1,0 +1,23 @@
+# FAIL: PRODUCT_VERSION is expected and is the name of the build arg, not VERSION
+# This dockerfile will set the value to 8.6 which comes from the UBI container but
+# does not match the PRODUCT_VERSION we expect
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as default
+
+ARG BIN_NAME
+# Export BIN_NAME for the CMD below, it can't see ARGs directly.
+ENV BIN_NAME=$BIN_NAME
+
+ARG VERSION
+ARG PRODUCT_REVISION
+ARG PRODUCT_NAME=$BIN_NAME
+# TARGETOS and TARGETARCH are set automatically when --platform is provided.
+ARG TARGETOS TARGETARCH
+
+LABEL maintainer="Team RelEng <team-rel-eng@hashicorp.com>"
+LABEL version=$VERSION
+LABEL revision=$PRODUCT_REVISION
+
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
+
+USER 100
+CMD ["/bin/$BIN_NAME", "default"]

--- a/scripts/testdata/input/version_label_unset.Dockerfile
+++ b/scripts/testdata/input/version_label_unset.Dockerfile
@@ -1,0 +1,22 @@
+# FAIL: PRODUCT_VERSION is expected and is the name of the build arg, not VERSION
+# This dockerfile should not set the version label
+FROM alpine:latest AS default
+
+ARG BIN_NAME
+# Export BIN_NAME for the CMD below, it can't see ARGs directly.
+ENV BIN_NAME=$BIN_NAME
+
+ARG VERSION
+ARG PRODUCT_REVISION
+ARG PRODUCT_NAME=$BIN_NAME
+# TARGETOS and TARGETARCH are set automatically when --platform is provided.
+ARG TARGETOS TARGETARCH
+
+LABEL maintainer="Team RelEng <team-rel-eng@hashicorp.com>"
+LABEL version=$VERSION
+LABEL revision=$PRODUCT_REVISION
+
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
+
+USER 100
+CMD ["/bin/$BIN_NAME", "default"]


### PR DESCRIPTION
### Justification

https://hashicorp.atlassian.net/browse/RELENG-20

### Summary

This adds a validation on the resulting built docker images to check whether it contains a `version` label. This version label is used in our internal tooling to inspect images on Dockerhub and determine if the currently-being-released version of software should update the `minor-latest` and `latest` tags as well. If a Dockerfile does not make use of `PRODUCT_VERSION` and if it's undefined, the value of the `version` label will be empty and could cause is to overwrite a newer `latest` software image with an older patch release. 
 
### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [X] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_