### PR TITLE
add context to version label validation

### DIFF
--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -77,10 +77,11 @@ docker buildx build --load \
 # validate version label is set to the correct value
 version_label_validation() {
 	val=$(docker inspect --format='{{ index .Config.Labels "version" }}' "${2}")
+	error_context="actions-docker-build passes a 'PRODUCT_VERSION' build-arg to the build. Ensure it is defined in the Dockerfile and the 'version' label uses it"
 	if [ "$val" = "" ]; then
-		die "Error: 'version' label must be set to version passed in but was empty"
+		die "Error: 'version' label must be set to version passed in but was empty.\n$error_context"
 	elif [ "$val" != "${1}" ]; then
-		die "Error: 'version' label must be set to version passed in but was ($val)"
+		die "Error: 'version' label must match the version passed in but was ($val).\n$error_context"
 	fi
 }
 


### PR DESCRIPTION
### Summary

This is a follow up to add a bit more context to the error message in #25 for how to fix the version label error.

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [X] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_