### PR TITLE
fix errant warning about replacing + in tags

### DIFF
--- a/scripts/digest_inputs
+++ b/scripts/digest_inputs
@@ -34,9 +34,9 @@ TAGS="${TAGS:-}"
 REDHAT_TAG="${REDHAT_TAG:-}"
 
 autocorrect_tags() {
-	local NEW_TAGS
+	local TAGS="$2" NEW_TAGS
 	trap 'echo "$NEW_TAGS"' RETURN
-	NEW_TAGS="$(tr + - <<< "$2")"
+	NEW_TAGS="$(tr + - <<< "$TAGS")"
 	[[ "$NEW_TAGS" = "$TAGS" ]] || warn "Input '$1' contains '+' character(s), replacing them with '-'."
 }
 


### PR DESCRIPTION
### Justification

Notification about the error in a Slack DM.

### Summary

Ensure we're comparing like with like when detecting if replacements have happened when autocorrecting tags.

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_