### PR TITLE
Upgrade upstream actions to v3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -125,7 +125,7 @@ runs:
       run: ${{ github.action_path }}/scripts/register_qemu_binfmt
 
     - name: Download Product Zip Artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ${{ env.ZIP_NAME }}
         path: ${{ env.ZIP_LOCATION }}
@@ -150,7 +150,7 @@ runs:
       run: ${{ github.action_path}}/scripts/create_metadata
 
     - name: Upload Docker Image metadata
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       env:
         # Add _redhat if this is a redhat call.
         REDHAT_SUFFIX: ${{ inputs.redhat_tag && '_redhat' || '' }}
@@ -160,7 +160,7 @@ runs:
         if-no-files-found: error
 
     - name: Upload Prod Tarball
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ env.TAGS != '' }}
       with:
         name: ${{ env.TARBALL_NAME }}
@@ -168,7 +168,7 @@ runs:
         if-no-files-found: error
 
     - name: Upload Dev Tarball
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ env.DEV_TAGS != '' }}
       with:
         name: ${{ env.DEV_TARBALL_NAME }}
@@ -176,7 +176,7 @@ runs:
         if-no-files-found: error
 
     - name: Upload Red Hat Tarball
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ env.REDHAT_TAG != '' }}
       with:
         name: ${{ env.REDHAT_TARBALL_NAME }}


### PR DESCRIPTION
### Justification

v2 actions use Node 12 runtime, which is deprecated and generates warnings: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

### Summary

Upgrading to v3 tags switches us to the Node 16 runtime.

Example warnings:

<img width="1460" alt="image" src="https://user-images.githubusercontent.com/4488707/203053340-98ba5b0a-0c91-4b65-bd6b-b1c408b4ec46.png">

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [x] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_