### PR TITLE
Enable default dev tags and PUSH_AUTO_DEV_TAG flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OVERRIDE_REDHAT_TARBALL_NAME: action-test-redhat-tag-only.docker.tar
-      TEST_REDHAT_TAG: scan.connect.redhat.com/ospid-blahblah/productname:1.2.3
+      TEST_REDHAT_TAG: quay.io/redhat-isv-containers/63111fb3496edcd88344ab5b:1.2.3
     needs:
       - action-test-prep
     steps:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,14 @@ see note on `redhat_tag` below.
 - **`dev_tags`** is similar to **tags** except these tags are not intended for
   production/final releases; **dev_tags** are typically published much more
   frequently than production tags, and are used for early access to the latest code.
-  Currently `dev_tags` must begin with `[docker.io/]hashicorppreview`.
+  Currently `dev_tags` must begin with `[docker.io/]hashicorppreview`. 
+- **`push_auto_dev_tags`** is a flag that can be passed in when calling the action to 
+  define whether the dev tags are pushed. Note that the default behaviour, when dev 
+  tags are defined, is to push dev tags:
+  - PUSH_AUTO_DEV_TAGS=true & no dev-tags defined: push default dev tags
+  - PUSH_AUTO_DEV_TAGS=true & dev-tags defined: push non-default dev tags
+  - PUSH_AUTO_DEV_TAGS=false/empty & no dev-tags defined: do NOT push dev tags
+  - PUSH_AUTO_DEV_TAGS=false/empty & dev-tags defined: push non-default dev tags
 - **`redhat_tag`** allows specifying a Red Hat tag to apply to the image.
   NOTE: If you specify `redhat_tag` you may not also specify `tags` or `dev_tags`.
 - **`smoke_test`** allows specifying a script to run immediately after the image

--- a/action.yml
+++ b/action.yml
@@ -43,10 +43,6 @@ inputs:
     description: Version of arm architecture to use (ignored unless arch == arm).
     default: 6
 
-  dev_tags:
-    description: Tags to use for publishing development images (optional).
-    default: ""
-
   smoke_test:
     description: >
       Bash shell script to run as a smoke test against the built image.
@@ -78,6 +74,15 @@ inputs:
       Name of the product binary inside the zip file. If empty (which is the default)
       then the name is guessed using repo name with any -enteprise suffix removed.
     default: ""
+
+  # Set defaults in scripts/digest_inputs.sh
+  dev_tags:
+    description: Tags to use for publishing development images (optional).
+    default: ""
+
+  push_auto_dev_tags:
+    description: Tag to determine whether to push default dev tags (optional).
+    default: "false"
 
   # Escape hatch inputs (use sparingly if at all).
   workdir:
@@ -113,6 +118,7 @@ runs:
 
         # Optional.
         DEV_TAGS: "${{ inputs.dev_tags }}"
+        PUSH_AUTO_DEV_TAGS: "${{ inputs.push_auto_dev_tags }}"
         ARM_VERSION: "${{ inputs.arm_version }}"
         PKG_NAME: "${{ inputs.pkg_name }}"
         WORKDIR: "${{ inputs.workdir }}"

--- a/scripts/digest_inputs
+++ b/scripts/digest_inputs
@@ -55,10 +55,6 @@ if [ "$PUSH_AUTO_DEV_TAGS" = true ] || ([[ ! -z "${DEV_TAGS}" ]]); then
   DEV_TAGS=${DEV_TAGS:=("hashicorppreview/${REPO_NAME}:${MINOR}-dev" "hashicorppreview/${REPO_NAME}:${MINOR}-dev-${REVISION}")}
 fi
 
-# Check that one of tags and redhags is set
-[ -n "${TAGS:-}${REDHAT_TAG:-}" ] || die "Must set either TAGS or REDHAT_TAG"
-[ -z "${TAGS:-}" ] || [ -z "${REDHAT_TAG:-}" ] || die "Must set either TAGS or REDHAT_TAG (not both)"
-
 autocorrect_tags() {
 	local TAGS="$2" NEW_TAGS
 	trap 'echo "$NEW_TAGS"' RETURN

--- a/scripts/digest_inputs
+++ b/scripts/digest_inputs
@@ -32,6 +32,19 @@ DEV_TAGS="${DEV_TAGS:-}"
 DOCKERFILE="${DOCKERFILE:-Dockerfile}"
 TAGS="${TAGS:-}"
 REDHAT_TAG="${REDHAT_TAG:-}"
+PUSH_AUTO_DEV_TAGS="${PUSH_AUTO_DEV_TAGS:=false}"
+
+# Strip version to MAJOR.MINOR
+MINOR="${VERSION%.*}"
+
+# Set default dev tags
+if [ "$PUSH_AUTO_DEV_TAGS" = true ] || ([[ ! -z "${DEV_TAGS}" ]]); then
+  DEV_TAGS=${DEV_TAGS:=("hashicorppreview/${REPO_NAME}:${MINOR}-dev" "hashicorppreview/${REPO_NAME}:${MINOR}-dev-${REVISION}")}
+fi
+
+# Check that one of tags and redhags is set
+[ -n "${TAGS:-}${REDHAT_TAG:-}" ] || die "Must set either TAGS or REDHAT_TAG"
+[ -z "${TAGS:-}" ] || [ -z "${REDHAT_TAG:-}" ] || die "Must set either TAGS or REDHAT_TAG (not both)"
 
 autocorrect_tags() {
 	local TAGS="$2" NEW_TAGS

--- a/scripts/digest_inputs
+++ b/scripts/digest_inputs
@@ -35,7 +35,20 @@ REDHAT_TAG="${REDHAT_TAG:-}"
 PUSH_AUTO_DEV_TAGS="${PUSH_AUTO_DEV_TAGS:=false}"
 
 # Strip version to MAJOR.MINOR
-MINOR="${VERSION%.*}"
+get_minor_version() {
+  MINOR=$(cut -c 1-3 <<< "$1")
+
+  # check that minor version is formatted correctly
+  patch='^[0-9]+$'
+  if [ ${#MINOR} != 3 ]; then
+    die "Version must be of format: MAJOR.MINOR.PATCH"
+  elif (! [[ $(cut -c 1-1 <<< ${MINOR}) =~ $patch ]]) || (! [[ $(cut -c 3-3 <<< ${MINOR}) =~ $patch ]]); then
+    die "Version must be of format: MAJOR.MINOR.PATCH"
+  elif [ $(cut -c 2-2 <<< ${MINOR}) != '.' ]; then
+    die "Version must be of format: MAJOR.MINOR.PATCH"
+  fi
+}
+get_minor_version ${VERSION}
 
 # Set default dev tags
 if [ "$PUSH_AUTO_DEV_TAGS" = true ] || ([[ ! -z "${DEV_TAGS}" ]]); then
@@ -181,3 +194,5 @@ if [ "$ARCH" = "arm" ]; then
 fi
 
 add_var PLATFORM
+
+add_var MINOR

--- a/scripts/docker_build.bats
+++ b/scripts/docker_build.bats
@@ -54,7 +54,7 @@ set_test_prod_tags() {
 }
 
 set_test_redhat_tag() {
-	export REDHAT_TAG1=scan.connect.redhat.com/blahblah.productname:1.2.3-ubi
+	export REDHAT_TAG1=quay.io/redhat-isv-containers/blahblah.productname:1.2.3-ubi
 
 	export REDHAT_TAG="$REDHAT_TAG1"
 }

--- a/scripts/testdata/want/github.env
+++ b/scripts/testdata/want/github.env
@@ -76,3 +76,6 @@ EOF
 PLATFORM<<EOF
 linux/amd64
 EOF
+MINOR<<EOF
+1.2
+EOF


### PR DESCRIPTION
### Justification

Pushing dev docker tags byy default and adding an `PUSH_AUTO_DEV_TAGS` flags. See JIRA ticket: https://hashicorp.atlassian.net/browse/RELENG-306

### Summary

Pushes default dev docker tags (if not defined): 
`hashicorppreview/<product-name>:<major>.<minor>-dev`
`hashicorppreview/<product-name>:<major>.<minor>-dev-<commit-sha>`

New behaviour:

1. PUSH_AUTO_DEV_TAGS=true & no dev-tags defined: push default dev tags
2. PUSH_AUTO_DEV_TAGS=true & dev-tags defined: push non-default dev tags
3. PUSH_AUTO_DEV_TAGS=false/empty & no dev-tags defined: do NOT push dev tags
4. PUSH_AUTO_DEV_TAGS=false/empty & dev-tags defined: push non-default dev tags

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_