### PR TITLE
adding optional REVISION input

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ see note on `redhat_tag` below.
 ### Action Inputs Explained
 
 - **`version`** is the product version we are building a docker image for.
+- **`revision`** is the revision that's being built. 
+  This may differ from the default <github.sha> which is the ref the action was invoked at.
 - **`target`** is the name of the "stage" or "target" in the Dockerfile to build.
 - **`arch`** is the architecture we're building for.
 - **`tags`** is a newline-separated list of the "production tags" for this image.

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,13 @@ inputs:
     description: Target image architecture.
     required: true
 
+  revision:
+    description: >
+      Full sha of the commit that is being built.
+      This may differ from the default <github.sha> which is the ref the action
+      was invoked at.
+    default: "${{ github.sha }}"
+
   tags:
     description: >
       Whitespace-separated fully-qualified image names to use for production releases.
@@ -114,7 +121,7 @@ runs:
       env:
 
         # Required.
-        REVISION: "${{ github.sha }}"
+        REVISION: "${{ inputs.revision }}"
         VERSION: "${{ inputs.version }}"
         ARCH: "${{ inputs.arch }}"
         TAGS: "${{ inputs.tags }}"


### PR DESCRIPTION
### Justification

https://hashicorp.slack.com/archives/G01ETP58BL1/p1687876497920969

### Summary

Adding an optional `REVISION` input to this action. This is the full sha of the commit that is being built. This may differ from the default <github.sha> which is the ref the action was invoked at. 

We already allow overwriting the default `github.sha` in `actions-generate-metadata` [here](https://github.com/hashicorp/actions-generate-metadata/blob/cc2615460a2a307e315f1bf9b8296735f330ddd5/action.yml#L30C4-L30C4). And since this is the source of truth for CRT, we should also make this configurable in the docker action. 

This value is used in this action to form the tar file name which is subsequently parsed when we attempt to load and push the images later in CRT. This should always match the sha in the `metadata.json`.

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [x] New or updated behavior which has been manually tested.
  https://github.com/hashicorp/crt-core-helloworld/actions/runs/5401678465/jobs/9811896798 (test that we do not break default behavior)
Tested by running a release build on this branch:
release build: https://github.com/hashicorp/nomad/actions/runs/5402001479 (using the build revision for the docker action)
prepare - https://github.com/hashicorp/crt-workflows-common/actions/runs/5402083028 (successful docker promotion to dev)
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_