### PR TITLE
Releng/redhat fix

### DIFF
--- a/scripts/digest_inputs
+++ b/scripts/digest_inputs
@@ -20,7 +20,6 @@ source "${BASH_SOURCE%/*}/validation.bash"
 [ -n "${ARCH:-}"       ] || die "Must set ARCH"
 [ -n "${TARGET:-}"     ] || die "Must set TARGET"
 [ -n "${TAGS:-}${REDHAT_TAG:-}" ] || die "Must set either TAGS or REDHAT_TAG"
-[ -z "${TAGS:-}" ] || [ -z "${REDHAT_TAG:-}" ] || die "Must set either TAGS or REDHAT_TAG (not both)"
 
 # Optional env vars.
 ARM_VERSION="${ARM_VERSION:-}"

--- a/scripts/digest_inputs.bats
+++ b/scripts/digest_inputs.bats
@@ -285,13 +285,6 @@ assert_failure_with_message_when() { local MESSAGE="$1"; shift
 
 }
 
-@test "redhat_tag and tags set / error" {
-	set_all_required_env_vars_and_tags
-	export REDHAT_TAG="blah"
-	WANT_ERR="Must set either TAGS or REDHAT_TAG (not both)"
-	assert_failure_with_message_when "$WANT_ERR" ./digest_inputs
-}
-
 @test "redhat_tags contains an old redhat tag / error" {
 	set_all_required_env_vars_and_tags
 	TAGS=""

--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -16,7 +16,6 @@ die() { echo "$1" 1>&2; exit 1; }
 [ -n "${PLATFORM:-}" ] || die "Must set PLATFORM"
 [ -n "${AUTO_TAG:-}" ] || die "Must set AUTO_TAG"
 [ -n "${TAGS:-}${REDHAT_TAG:-}" ] || die "Must set either TAG or REDHAT_TAG"
-[ -z "${TAGS:-}" ] || [ -z "${REDHAT_TAG:-}" ] || die "Must set either TAG or REDHAT_TAG (not both)"
 
 
 WORKDIR="${WORKDIR:-.}"


### PR DESCRIPTION
### Justification

Now that Redhat supports multi-arch images, we suggest product teams do `UBI` builds in one step (tagging both for `dockerhub` and `quay.io` in one build step). 

As such, we need to remove the current _exclusive or_ between `dockerhub/AWS` tags and `quay.io` tags from the variable check. This error occurred in [this](https://github.com/hashicorp/vault-secrets-operator/pull/480) product repo PR.

This PR includes:

  - [x] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
Tested via `crt-core-helloworld`:
[build](https://github.com/hashicorp/crt-core-helloworld/actions/workflows/build.yml)
[prepare](https://github.com/hashicorp/crt-workflows-common/actions/runs/7011068532)
[promote](https://github.com/hashicorp/crt-workflows-common/actions/runs/7011323854/job/19073703547)