### PR TITLE
Add support for extra build args

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ you must call it multiple times in order to build multiple architectures.
   - PUSH_AUTO_DEV_TAGS=false/empty & dev-tags defined: push non-default dev tags
 - **`smoke_test`** allows specifying a script to run immediately after the image
   is built, to perform some basic checks on the image. See note on `smoke_test` below.
+- `extra_build_args` is a newline-separated list of extra build args to pass
+  to `docker build`. (optional)
 
 #### Note on `target`
 

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,12 @@ inputs:
     description: Tag to determine whether to push default dev tags (optional).
     default: "false"
 
+  extra_build_args:
+    description: >
+      Whitespace-separated list of extra build arguments that get passed to docker 
+      build (optional).
+    default: ""
+
   # Escape hatch inputs (use sparingly if at all).
   workdir:
     description: Working directory in which to run 'docker build'.

--- a/scripts/digest_inputs
+++ b/scripts/digest_inputs
@@ -14,11 +14,11 @@ source "${BASH_SOURCE%/*}/validation.bash"
 
 # Required env vars.
 [ -n "${GITHUB_ENV:-}" ] || die "Must set GITHUB_ENV"
-[ -n "${REPO_NAME:-}"  ] || die "Must set REPO_NAME"
-[ -n "${REVISION:-}"   ] || die "Must set REVISION"
-[ -n "${VERSION:-}"    ] || die "Must set VERSION"
-[ -n "${ARCH:-}"       ] || die "Must set ARCH"
-[ -n "${TARGET:-}"     ] || die "Must set TARGET"
+[ -n "${REPO_NAME:-}" ] || die "Must set REPO_NAME"
+[ -n "${REVISION:-}" ] || die "Must set REVISION"
+[ -n "${VERSION:-}" ] || die "Must set VERSION"
+[ -n "${ARCH:-}" ] || die "Must set ARCH"
+[ -n "${TARGET:-}" ] || die "Must set TARGET"
 [ -n "${TAGS:-}${REDHAT_TAG:-}" ] || die "Must set either TAGS or REDHAT_TAG"
 
 # Optional env vars.
@@ -28,6 +28,7 @@ WORKDIR="${WORKDIR:-}"
 ZIP_NAME="${ZIP_NAME:-}"
 BIN_NAME="${BIN_NAME:-}"
 DEV_TAGS="${DEV_TAGS:-}"
+EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS:-}"
 DOCKERFILE="${DOCKERFILE:-Dockerfile}"
 TAGS="${TAGS:-}"
 REDHAT_TAG="${REDHAT_TAG:-}"
@@ -36,35 +37,35 @@ OS_VERSION="${OS_VERSION:-}"
 
 # Strip version to MAJOR.MINOR
 get_minor_version() {
-  MINOR=$(cut -c 1-3 <<< "$1")
+	MINOR=$(cut -c 1-3 <<<"$1")
 
-  # check that minor version is formatted correctly
-  patch='^[0-9]+$'
-  if [ ${#MINOR} != 3 ]; then
-    die "Version must be of format: MAJOR.MINOR.PATCH"
-  elif (! [[ $(cut -c 1-1 <<< ${MINOR}) =~ $patch ]]) || (! [[ $(cut -c 3-3 <<< ${MINOR}) =~ $patch ]]); then
-    die "Version must be of format: MAJOR.MINOR.PATCH"
-  elif [ $(cut -c 2-2 <<< ${MINOR}) != '.' ]; then
-    die "Version must be of format: MAJOR.MINOR.PATCH"
-  fi
+	# check that minor version is formatted correctly
+	patch='^[0-9]+$'
+	if [ ${#MINOR} != 3 ]; then
+		die "Version must be of format: MAJOR.MINOR.PATCH"
+	elif (! [[ $(cut -c 1-1 <<<${MINOR}) =~ $patch ]]) || (! [[ $(cut -c 3-3 <<<${MINOR}) =~ $patch ]]); then
+		die "Version must be of format: MAJOR.MINOR.PATCH"
+	elif [ $(cut -c 2-2 <<<${MINOR}) != '.' ]; then
+		die "Version must be of format: MAJOR.MINOR.PATCH"
+	fi
 }
 get_minor_version ${VERSION}
 
 # Set default dev tags
 if [ "$PUSH_AUTO_DEV_TAGS" = true ] || ([[ ! -z "${DEV_TAGS}" ]]); then
-  DEV_TAGS=${DEV_TAGS:=("hashicorppreview/${REPO_NAME}:${MINOR}-dev" "hashicorppreview/${REPO_NAME}:${MINOR}-dev-${REVISION}")}
+	DEV_TAGS=${DEV_TAGS:=("hashicorppreview/${REPO_NAME}:${MINOR}-dev" "hashicorppreview/${REPO_NAME}:${MINOR}-dev-${REVISION}")}
 fi
 
 autocorrect_tags() {
 	local TAGS="$2" NEW_TAGS
 	trap 'echo "$NEW_TAGS"' RETURN
-	NEW_TAGS="$(tr + - <<< "$TAGS")"
+	NEW_TAGS="$(tr + - <<<"$TAGS")"
 	[[ "$NEW_TAGS" = "$TAGS" ]] || warn "Input '$1' contains '+' character(s), replacing them with '-'."
 }
 
 # Autocorrect tags.
-TAGS="$(autocorrect_tags       tags       "$TAGS")"
-DEV_TAGS="$(autocorrect_tags   dev_tags   "$DEV_TAGS")"
+TAGS="$(autocorrect_tags tags "$TAGS")"
+DEV_TAGS="$(autocorrect_tags dev_tags "$DEV_TAGS")"
 REDHAT_TAG="$(autocorrect_tags redhat_tag "$REDHAT_TAG")"
 
 # Validate tags.
@@ -74,13 +75,13 @@ dev_tags_validation "$DEV_TAGS"
 
 # Funcs to add variables to GITHUB_ENV.
 add_var() {
-  {
-    echo "$1<<EOF"
-    echo "${!1}"
-    echo "EOF"
-  } >> "$GITHUB_ENV"
-  echo "export $1='${!1}'" >> "$GITHUB_ENV.export"
-  echo "--> Set $1 to '${!1}'"
+	{
+		echo "$1<<EOF"
+		echo "${!1}"
+		echo "EOF"
+	} >>"$GITHUB_ENV"
+	echo "export $1='${!1}'" >>"$GITHUB_ENV.export"
+	echo "--> Set $1 to '${!1}'"
 }
 
 add_vars() { for NAME in "$@"; do add_var "$NAME"; done; }
@@ -102,13 +103,13 @@ ENTERPRISE_DETECTED=false
 # This checks if removing '-enterprise' suffix actually did anything.
 # If it did, then we've detected a likely enterprise repo.
 [ "$REPO_NAME" != "$REPO_NAME_MINUS_ENTERPRISE" ] && {
-  ENTERPRISE_DETECTED=true
-  # If the version doesn't contain a '+' or '-ent' then add the '+ent' suffix.
-  if [[ ! "$VERSION" =~ .*\+.* ]] && [[ ! "$VERSION" =~ .*-ent.* ]]; then
-	NEW_VERSION="$VERSION+ent"
-    warn "Appending '+ent' to the version string '$VERSION' -> '$NEW_VERSION' add '+ent' to the version input to remove this warning."
-	VERSION="$NEW_VERSION"
-  fi
+	ENTERPRISE_DETECTED=true
+	# If the version doesn't contain a '+' or '-ent' then add the '+ent' suffix.
+	if [[ ! "$VERSION" =~ .*\+.* ]] && [[ ! "$VERSION" =~ .*-ent.* ]]; then
+		NEW_VERSION="$VERSION+ent"
+		warn "Appending '+ent' to the version string '$VERSION' -> '$NEW_VERSION' add '+ent' to the version input to remove this warning."
+		VERSION="$NEW_VERSION"
+	fi
 }
 
 # If the version contains '-ent' then rectify this to '+ent' for the sake
@@ -128,14 +129,14 @@ add_vars REPO_NAME REPO_NAME_MINUS_ENTERPRISE ENTERPRISE_DETECTED
 # Get some basic info needed to building and tagging the docker image.
 
 case "$(uname -s)" in
-    Linux*)     OS=linux;;
-    Darwin*)    OS=osx;;
-    CYGWIN*)    OS=windows;;
-    MINGW*)     OS=windows;;
-    *)
-        echo "Unsupported OS: $(uname -s)"
-        exit 1
-        ;;
+Linux*) OS=linux ;;
+Darwin*) OS=osx ;;
+CYGWIN*) OS=windows ;;
+MINGW*) OS=windows ;;
+*)
+	echo "Unsupported OS: $(uname -s)"
+	exit 1
+	;;
 esac
 
 add_vars TARGET OS ARCH VERSION REVISION OS_VERSION
@@ -143,7 +144,7 @@ add_vars TARGET OS ARCH VERSION REVISION OS_VERSION
 # Determine package name used for default zip file name.
 PKG_NAME_GUESSED=false
 [ -n "$PKG_NAME" ] || {
-  PKG_NAME="${REPO_NAME_MINUS_ENTERPRISE}_${VERSION}"
+	PKG_NAME="${REPO_NAME_MINUS_ENTERPRISE}_${VERSION}"
 }
 
 add_vars PKG_NAME PKG_NAME_GUESSED
@@ -155,8 +156,8 @@ add_vars PKG_NAME PKG_NAME_GUESSED
 ZIP_LOCATION="$WORKDIR/dist/$OS/$ARCH"
 ZIP_NAME_GUESSED=false
 [ -n "$ZIP_NAME" ] || {
-  ZIP_NAME_GUESSED=true
-  ZIP_NAME="${PKG_NAME}_${OS}_${ARCH}.zip"
+	ZIP_NAME_GUESSED=true
+	ZIP_NAME="${PKG_NAME}_${OS}_${ARCH}.zip"
 }
 
 add_vars ZIP_LOCATION ZIP_NAME ZIP_NAME_GUESSED
@@ -166,7 +167,7 @@ add_vars ZIP_LOCATION ZIP_NAME ZIP_NAME_GUESSED
 TARBALL_ROOT="${REPO_NAME}_${TARGET}_${OS}_${ARCH}_${VERSION}_${REVISION}"
 # Some OS's like windows need to specify an os version. If it's set, let's embed it in the docker tarball name
 if [[ -n "${OS_VERSION}" ]]; then
-  TARBALL_ROOT="${REPO_NAME}_${TARGET}_${OS}_${OS_VERSION}_${ARCH}_${VERSION}_${REVISION}"
+	TARBALL_ROOT="${REPO_NAME}_${TARGET}_${OS}_${OS_VERSION}_${ARCH}_${VERSION}_${REVISION}"
 fi
 DEFAULT_TARBALL_NAME="${TARBALL_ROOT}.docker.tar"
 DEFAULT_DEV_TARBALL_NAME="${TARBALL_ROOT}.docker.dev.tar"
@@ -183,18 +184,18 @@ REDHAT_TARBALL_NAME="${OVERRIDE_REDHAT_TARBALL_NAME:-$DEFAULT_REDHAT_TARBALL_NAM
 
 AUTO_TAG="${REPO_NAME}/${TARGET}/${OS}/${ARCH}:${VERSION//+/-}_${REVISION}"
 
-add_vars TARBALL_NAME DEV_TARBALL_NAME REDHAT_TARBALL_NAME  AUTO_TAG
+add_vars TARBALL_NAME DEV_TARBALL_NAME REDHAT_TARBALL_NAME AUTO_TAG
 
 # Determine product bin name.
 BIN_NAME_GUESSED=false
 # Guess bin name if none provided.
 if [ -z "$BIN_NAME" ]; then
-  BIN_NAME="$REPO_NAME_MINUS_ENTERPRISE"
-  # Windows binaries need the .exe suffix so we need to make sure that it is there for the OS.
-  if [[ "$OS" == "windows" ]]; then
-  BIN_NAME="${BIN_NAME}.exe"
-  fi
-  BIN_NAME_GUESSED=true
+	BIN_NAME="$REPO_NAME_MINUS_ENTERPRISE"
+	# Windows binaries need the .exe suffix so we need to make sure that it is there for the OS.
+	if [[ "$OS" == "windows" ]]; then
+		BIN_NAME="${BIN_NAME}.exe"
+	fi
+	BIN_NAME_GUESSED=true
 fi
 
 add_vars BIN_NAME BIN_NAME_GUESSED
@@ -202,9 +203,13 @@ add_vars BIN_NAME BIN_NAME_GUESSED
 # Docker Platform
 PLATFORM="$OS/$ARCH"
 if [ "$ARCH" = "arm" ]; then
-  PLATFORM="$PLATFORM/v$ARM_VERSION"
+	PLATFORM="$PLATFORM/v$ARM_VERSION"
 fi
 
 add_var PLATFORM
 
 add_var MINOR
+
+if [ -n "$EXTRA_BUILD_ARGS" ]; then
+	add_var EXTRA_BUILD_ARGS
+fi

--- a/scripts/digest_inputs
+++ b/scripts/digest_inputs
@@ -14,11 +14,11 @@ source "${BASH_SOURCE%/*}/validation.bash"
 
 # Required env vars.
 [ -n "${GITHUB_ENV:-}" ] || die "Must set GITHUB_ENV"
-[ -n "${REPO_NAME:-}" ] || die "Must set REPO_NAME"
-[ -n "${REVISION:-}" ] || die "Must set REVISION"
-[ -n "${VERSION:-}" ] || die "Must set VERSION"
-[ -n "${ARCH:-}" ] || die "Must set ARCH"
-[ -n "${TARGET:-}" ] || die "Must set TARGET"
+[ -n "${REPO_NAME:-}"  ] || die "Must set REPO_NAME"
+[ -n "${REVISION:-}"   ] || die "Must set REVISION"
+[ -n "${VERSION:-}"    ] || die "Must set VERSION"
+[ -n "${ARCH:-}"       ] || die "Must set ARCH"
+[ -n "${TARGET:-}"     ] || die "Must set TARGET"
 [ -n "${TAGS:-}${REDHAT_TAG:-}" ] || die "Must set either TAGS or REDHAT_TAG"
 
 # Optional env vars.
@@ -28,44 +28,44 @@ WORKDIR="${WORKDIR:-}"
 ZIP_NAME="${ZIP_NAME:-}"
 BIN_NAME="${BIN_NAME:-}"
 DEV_TAGS="${DEV_TAGS:-}"
-EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS:-}"
 DOCKERFILE="${DOCKERFILE:-Dockerfile}"
 TAGS="${TAGS:-}"
 REDHAT_TAG="${REDHAT_TAG:-}"
 PUSH_AUTO_DEV_TAGS="${PUSH_AUTO_DEV_TAGS:=false}"
 OS_VERSION="${OS_VERSION:-}"
+EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS:-}"
 
 # Strip version to MAJOR.MINOR
 get_minor_version() {
-	MINOR=$(cut -c 1-3 <<<"$1")
+  MINOR=$(cut -c 1-3 <<< "$1")
 
-	# check that minor version is formatted correctly
-	patch='^[0-9]+$'
-	if [ ${#MINOR} != 3 ]; then
-		die "Version must be of format: MAJOR.MINOR.PATCH"
-	elif (! [[ $(cut -c 1-1 <<<${MINOR}) =~ $patch ]]) || (! [[ $(cut -c 3-3 <<<${MINOR}) =~ $patch ]]); then
-		die "Version must be of format: MAJOR.MINOR.PATCH"
-	elif [ $(cut -c 2-2 <<<${MINOR}) != '.' ]; then
-		die "Version must be of format: MAJOR.MINOR.PATCH"
-	fi
+  # check that minor version is formatted correctly
+  patch='^[0-9]+$'
+  if [ ${#MINOR} != 3 ]; then
+    die "Version must be of format: MAJOR.MINOR.PATCH"
+  elif (! [[ $(cut -c 1-1 <<< ${MINOR}) =~ $patch ]]) || (! [[ $(cut -c 3-3 <<< ${MINOR}) =~ $patch ]]); then
+    die "Version must be of format: MAJOR.MINOR.PATCH"
+  elif [ $(cut -c 2-2 <<< ${MINOR}) != '.' ]; then
+    die "Version must be of format: MAJOR.MINOR.PATCH"
+  fi
 }
 get_minor_version ${VERSION}
 
 # Set default dev tags
 if [ "$PUSH_AUTO_DEV_TAGS" = true ] || ([[ ! -z "${DEV_TAGS}" ]]); then
-	DEV_TAGS=${DEV_TAGS:=("hashicorppreview/${REPO_NAME}:${MINOR}-dev" "hashicorppreview/${REPO_NAME}:${MINOR}-dev-${REVISION}")}
+  DEV_TAGS=${DEV_TAGS:=("hashicorppreview/${REPO_NAME}:${MINOR}-dev" "hashicorppreview/${REPO_NAME}:${MINOR}-dev-${REVISION}")}
 fi
 
 autocorrect_tags() {
 	local TAGS="$2" NEW_TAGS
 	trap 'echo "$NEW_TAGS"' RETURN
-	NEW_TAGS="$(tr + - <<<"$TAGS")"
+	NEW_TAGS="$(tr + - <<< "$TAGS")"
 	[[ "$NEW_TAGS" = "$TAGS" ]] || warn "Input '$1' contains '+' character(s), replacing them with '-'."
 }
 
 # Autocorrect tags.
-TAGS="$(autocorrect_tags tags "$TAGS")"
-DEV_TAGS="$(autocorrect_tags dev_tags "$DEV_TAGS")"
+TAGS="$(autocorrect_tags       tags       "$TAGS")"
+DEV_TAGS="$(autocorrect_tags   dev_tags   "$DEV_TAGS")"
 REDHAT_TAG="$(autocorrect_tags redhat_tag "$REDHAT_TAG")"
 
 # Validate tags.
@@ -75,13 +75,13 @@ dev_tags_validation "$DEV_TAGS"
 
 # Funcs to add variables to GITHUB_ENV.
 add_var() {
-	{
-		echo "$1<<EOF"
-		echo "${!1}"
-		echo "EOF"
-	} >>"$GITHUB_ENV"
-	echo "export $1='${!1}'" >>"$GITHUB_ENV.export"
-	echo "--> Set $1 to '${!1}'"
+  {
+    echo "$1<<EOF"
+    echo "${!1}"
+    echo "EOF"
+  } >> "$GITHUB_ENV"
+  echo "export $1='${!1}'" >> "$GITHUB_ENV.export"
+  echo "--> Set $1 to '${!1}'"
 }
 
 add_vars() { for NAME in "$@"; do add_var "$NAME"; done; }
@@ -103,13 +103,13 @@ ENTERPRISE_DETECTED=false
 # This checks if removing '-enterprise' suffix actually did anything.
 # If it did, then we've detected a likely enterprise repo.
 [ "$REPO_NAME" != "$REPO_NAME_MINUS_ENTERPRISE" ] && {
-	ENTERPRISE_DETECTED=true
-	# If the version doesn't contain a '+' or '-ent' then add the '+ent' suffix.
-	if [[ ! "$VERSION" =~ .*\+.* ]] && [[ ! "$VERSION" =~ .*-ent.* ]]; then
-		NEW_VERSION="$VERSION+ent"
-		warn "Appending '+ent' to the version string '$VERSION' -> '$NEW_VERSION' add '+ent' to the version input to remove this warning."
-		VERSION="$NEW_VERSION"
-	fi
+  ENTERPRISE_DETECTED=true
+  # If the version doesn't contain a '+' or '-ent' then add the '+ent' suffix.
+  if [[ ! "$VERSION" =~ .*\+.* ]] && [[ ! "$VERSION" =~ .*-ent.* ]]; then
+	NEW_VERSION="$VERSION+ent"
+    warn "Appending '+ent' to the version string '$VERSION' -> '$NEW_VERSION' add '+ent' to the version input to remove this warning."
+	VERSION="$NEW_VERSION"
+  fi
 }
 
 # If the version contains '-ent' then rectify this to '+ent' for the sake
@@ -129,14 +129,14 @@ add_vars REPO_NAME REPO_NAME_MINUS_ENTERPRISE ENTERPRISE_DETECTED
 # Get some basic info needed to building and tagging the docker image.
 
 case "$(uname -s)" in
-Linux*) OS=linux ;;
-Darwin*) OS=osx ;;
-CYGWIN*) OS=windows ;;
-MINGW*) OS=windows ;;
-*)
-	echo "Unsupported OS: $(uname -s)"
-	exit 1
-	;;
+    Linux*)     OS=linux;;
+    Darwin*)    OS=osx;;
+    CYGWIN*)    OS=windows;;
+    MINGW*)     OS=windows;;
+    *)
+        echo "Unsupported OS: $(uname -s)"
+        exit 1
+        ;;
 esac
 
 add_vars TARGET OS ARCH VERSION REVISION OS_VERSION
@@ -144,7 +144,7 @@ add_vars TARGET OS ARCH VERSION REVISION OS_VERSION
 # Determine package name used for default zip file name.
 PKG_NAME_GUESSED=false
 [ -n "$PKG_NAME" ] || {
-	PKG_NAME="${REPO_NAME_MINUS_ENTERPRISE}_${VERSION}"
+  PKG_NAME="${REPO_NAME_MINUS_ENTERPRISE}_${VERSION}"
 }
 
 add_vars PKG_NAME PKG_NAME_GUESSED
@@ -156,8 +156,8 @@ add_vars PKG_NAME PKG_NAME_GUESSED
 ZIP_LOCATION="$WORKDIR/dist/$OS/$ARCH"
 ZIP_NAME_GUESSED=false
 [ -n "$ZIP_NAME" ] || {
-	ZIP_NAME_GUESSED=true
-	ZIP_NAME="${PKG_NAME}_${OS}_${ARCH}.zip"
+  ZIP_NAME_GUESSED=true
+  ZIP_NAME="${PKG_NAME}_${OS}_${ARCH}.zip"
 }
 
 add_vars ZIP_LOCATION ZIP_NAME ZIP_NAME_GUESSED
@@ -167,7 +167,7 @@ add_vars ZIP_LOCATION ZIP_NAME ZIP_NAME_GUESSED
 TARBALL_ROOT="${REPO_NAME}_${TARGET}_${OS}_${ARCH}_${VERSION}_${REVISION}"
 # Some OS's like windows need to specify an os version. If it's set, let's embed it in the docker tarball name
 if [[ -n "${OS_VERSION}" ]]; then
-	TARBALL_ROOT="${REPO_NAME}_${TARGET}_${OS}_${OS_VERSION}_${ARCH}_${VERSION}_${REVISION}"
+  TARBALL_ROOT="${REPO_NAME}_${TARGET}_${OS}_${OS_VERSION}_${ARCH}_${VERSION}_${REVISION}"
 fi
 DEFAULT_TARBALL_NAME="${TARBALL_ROOT}.docker.tar"
 DEFAULT_DEV_TARBALL_NAME="${TARBALL_ROOT}.docker.dev.tar"
@@ -184,18 +184,18 @@ REDHAT_TARBALL_NAME="${OVERRIDE_REDHAT_TARBALL_NAME:-$DEFAULT_REDHAT_TARBALL_NAM
 
 AUTO_TAG="${REPO_NAME}/${TARGET}/${OS}/${ARCH}:${VERSION//+/-}_${REVISION}"
 
-add_vars TARBALL_NAME DEV_TARBALL_NAME REDHAT_TARBALL_NAME AUTO_TAG
+add_vars TARBALL_NAME DEV_TARBALL_NAME REDHAT_TARBALL_NAME  AUTO_TAG
 
 # Determine product bin name.
 BIN_NAME_GUESSED=false
 # Guess bin name if none provided.
 if [ -z "$BIN_NAME" ]; then
-	BIN_NAME="$REPO_NAME_MINUS_ENTERPRISE"
-	# Windows binaries need the .exe suffix so we need to make sure that it is there for the OS.
-	if [[ "$OS" == "windows" ]]; then
-		BIN_NAME="${BIN_NAME}.exe"
-	fi
-	BIN_NAME_GUESSED=true
+  BIN_NAME="$REPO_NAME_MINUS_ENTERPRISE"
+  # Windows binaries need the .exe suffix so we need to make sure that it is there for the OS.
+  if [[ "$OS" == "windows" ]]; then
+  BIN_NAME="${BIN_NAME}.exe"
+  fi
+  BIN_NAME_GUESSED=true
 fi
 
 add_vars BIN_NAME BIN_NAME_GUESSED
@@ -203,7 +203,7 @@ add_vars BIN_NAME BIN_NAME_GUESSED
 # Docker Platform
 PLATFORM="$OS/$ARCH"
 if [ "$ARCH" = "arm" ]; then
-	PLATFORM="$PLATFORM/v$ARM_VERSION"
+  PLATFORM="$PLATFORM/v$ARM_VERSION"
 fi
 
 add_var PLATFORM
@@ -211,5 +211,5 @@ add_var PLATFORM
 add_var MINOR
 
 if [ -n "$EXTRA_BUILD_ARGS" ]; then
-	add_var EXTRA_BUILD_ARGS
+  add_var EXTRA_BUILD_ARGS
 fi

--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -2,10 +2,7 @@
 
 set -Eeuo pipefail
 
-die() {
-	echo "$1" 1>&2
-	exit 1
-}
+die() { echo "$1" 1>&2; exit 1; }
 
 # Required env vars.
 [ -n "${BIN_NAME:-}" ] || die "Must set BIN_NAME"
@@ -20,20 +17,20 @@ die() {
 [ -n "${AUTO_TAG:-}" ] || die "Must set AUTO_TAG"
 [ -n "${TAGS:-}${REDHAT_TAG:-}" ] || die "Must set either TAG or REDHAT_TAG"
 
+
 WORKDIR="${WORKDIR:-.}"
 
-# Optional environment variables
 export DEV_TAGS="${DEV_TAGS:-}"
 export REDHAT_TAG="${REDHAT_TAG:-}"
 export EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS:-}"
 
 # Convert all contiguous blocks of whitespace to single spaces using xargs.
 # This is needed to get all tags on one line for the read -ra below.
-PROD_TAGS="$(xargs <<<"$TAGS")"
-DEV_TAGS="$(xargs <<<"$DEV_TAGS")"
+PROD_TAGS="$(xargs <<< "$TAGS")"
+DEV_TAGS="$(xargs <<< "$DEV_TAGS")"
 
-read -ra DEV_TAGS_A <<<"$DEV_TAGS"
-read -ra PROD_TAGS_A <<<"$PROD_TAGS"
+read -ra DEV_TAGS_A <<< "$DEV_TAGS"
+read -ra PROD_TAGS_A <<< "$PROD_TAGS"
 
 ALL_TAGS=("${DEV_TAGS_A[@]}")
 ALL_TAGS+=("$AUTO_TAG")
@@ -42,6 +39,7 @@ if [ -n "$REDHAT_TAG" ]; then
 	ALL_TAGS+=("${REDHAT_TAG}")
 fi
 echo "ALL_TAGS:" "${ALL_TAGS[@]}"
+
 
 for T in "${ALL_TAGS[@]}"; do
 	TAG_FLAGS+=("--tag=$T")
@@ -57,25 +55,25 @@ done
 
 # Append any extra build args to the final list of build args.
 if [ -n "$EXTRA_BUILD_ARGS" ]; then
-	# Convert all contiguous blocks of whitespace to single spaces using xargs.
-	# This is needed to get all tags on one line for the read -ra below.
-	EXTRA_BUILD_ARGS="$(xargs <<<"$EXTRA_BUILD_ARGS")"
+  # Convert all contiguous blocks of whitespace to single spaces using xargs.
+  # This is needed to get all tags on one line for the read -ra below.
+  EXTRA_BUILD_ARGS="$(xargs <<<"$EXTRA_BUILD_ARGS")"
 
-	read -ra EXTRA_BUILD_ARGS_A <<<"$EXTRA_BUILD_ARGS"
-	for E in "${EXTRA_BUILD_ARGS_A[@]}"; do
-		BA_FLAGS+=("--build-arg=$E")
-	done
+  read -ra EXTRA_BUILD_ARGS_A <<<"$EXTRA_BUILD_ARGS"
+  for E in "${EXTRA_BUILD_ARGS_A[@]}"; do
+    BA_FLAGS+=("--build-arg=$E")
+  done
 fi
 
 if [[ "$OS" == "windows" ]]; then
-	# Warning: Our Dockerfiles refer to TARGETOS and TARGETARCH.
-	# They claim it's set "automatically when --platform is provided."
-	# Lies.
-	# Maybe that's a buildx feature, because build doesn't. So we need to manually inject it.
-	BA_FLAGS+=(
-		"--build-arg=TARGETOS=${OS}"
-		"--build-arg=TARGETARCH=${PLATFORM#*/}"
-	)
+  # Warning: Our Dockerfiles refer to TARGETOS and TARGETARCH.
+  # They claim it's set "automatically when --platform is provided."
+  # Lies.
+  # Maybe that's a buildx feature, because build doesn't. So we need to manually inject it.
+  BA_FLAGS+=(
+    "--build-arg=TARGETOS=${OS}"
+    "--build-arg=TARGETARCH=${PLATFORM#*/}"
+  )
 fi
 
 TARBALL_PATH="$PWD/$TARBALL_NAME"
@@ -84,31 +82,31 @@ REDHAT_TARBALL_PATH="$PWD/$REDHAT_TARBALL_NAME"
 
 cd "$WORKDIR"
 
+
 echo "==> Building image with tags:"
 for T in "${ALL_TAGS[@]}"; do
-	echo "    - $T"
+  echo "    - $T"
 done
 
 if [[ "$OS" == "linux" ]]; then
-	docker buildx create --use
-	docker buildx build --load \
-		--target "$TARGET" \
-		--platform "$PLATFORM" \
-		"${TAG_FLAGS[@]}" \
-		"${BA_FLAGS[@]}" \
-		-f "$DOCKERFILE" \
-		.
+docker buildx create --use
+docker buildx build --load \
+  --target "$TARGET" \
+  --platform "$PLATFORM" \
+  "${TAG_FLAGS[@]}" \
+  "${BA_FLAGS[@]}" \
+  -f "$DOCKERFILE" \
+  .
 else
-	(
-		set -x
-		docker build \
-			--target "$TARGET" \
-			--platform "$PLATFORM" \
-			"${TAG_FLAGS[@]}" \
-			"${BA_FLAGS[@]}" \
-			-f "$DOCKERFILE" \
-			.
-	)
+  (set -x;
+  docker build \
+  --target "$TARGET" \
+  --platform "$PLATFORM" \
+  "${TAG_FLAGS[@]}" \
+  "${BA_FLAGS[@]}" \
+  -f "$DOCKERFILE" \
+  .
+  )
 fi
 
 # validate version label is set to the correct value

--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -2,7 +2,10 @@
 
 set -Eeuo pipefail
 
-die() { echo "$1" 1>&2; exit 1; }
+die() {
+	echo "$1" 1>&2
+	exit 1
+}
 
 # Required env vars.
 [ -n "${BIN_NAME:-}" ] || die "Must set BIN_NAME"
@@ -17,19 +20,20 @@ die() { echo "$1" 1>&2; exit 1; }
 [ -n "${AUTO_TAG:-}" ] || die "Must set AUTO_TAG"
 [ -n "${TAGS:-}${REDHAT_TAG:-}" ] || die "Must set either TAG or REDHAT_TAG"
 
-
 WORKDIR="${WORKDIR:-.}"
 
+# Optional environment variables
 export DEV_TAGS="${DEV_TAGS:-}"
 export REDHAT_TAG="${REDHAT_TAG:-}"
+export EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS:-}"
 
 # Convert all contiguous blocks of whitespace to single spaces using xargs.
 # This is needed to get all tags on one line for the read -ra below.
-PROD_TAGS="$(xargs <<< "$TAGS")"
-DEV_TAGS="$(xargs <<< "$DEV_TAGS")"
+PROD_TAGS="$(xargs <<<"$TAGS")"
+DEV_TAGS="$(xargs <<<"$DEV_TAGS")"
 
-read -ra DEV_TAGS_A <<< "$DEV_TAGS"
-read -ra PROD_TAGS_A <<< "$PROD_TAGS"
+read -ra DEV_TAGS_A <<<"$DEV_TAGS"
+read -ra PROD_TAGS_A <<<"$PROD_TAGS"
 
 ALL_TAGS=("${DEV_TAGS_A[@]}")
 ALL_TAGS+=("$AUTO_TAG")
@@ -38,7 +42,6 @@ if [ -n "$REDHAT_TAG" ]; then
 	ALL_TAGS+=("${REDHAT_TAG}")
 fi
 echo "ALL_TAGS:" "${ALL_TAGS[@]}"
-
 
 for T in "${ALL_TAGS[@]}"; do
 	TAG_FLAGS+=("--tag=$T")
@@ -51,15 +54,28 @@ BUILD_ARGS+=("PRODUCT_REVISION=$REVISION")
 for B in "${BUILD_ARGS[@]}"; do
 	BA_FLAGS+=("--build-arg=$B")
 done
+
+# Append any extra build args to the final list of build args.
+if [ -n "$EXTRA_BUILD_ARGS" ]; then
+	# Convert all contiguous blocks of whitespace to single spaces using xargs.
+	# This is needed to get all tags on one line for the read -ra below.
+	EXTRA_BUILD_ARGS="$(xargs <<<"$EXTRA_BUILD_ARGS")"
+
+	read -ra EXTRA_BUILD_ARGS_A <<<"$EXTRA_BUILD_ARGS"
+	for E in "${EXTRA_BUILD_ARGS_A[@]}"; do
+		BA_FLAGS+=("--build-arg=$E")
+	done
+fi
+
 if [[ "$OS" == "windows" ]]; then
-  # Warning: Our Dockerfiles refer to TARGETOS and TARGETARCH.
-  # They claim it's set "automatically when --platform is provided."
-  # Lies.
-  # Maybe that's a buildx feature, because build doesn't. So we need to manually inject it.
-  BA_FLAGS+=(
-    "--build-arg=TARGETOS=${OS}"
-    "--build-arg=TARGETARCH=${PLATFORM#*/}"
-  )
+	# Warning: Our Dockerfiles refer to TARGETOS and TARGETARCH.
+	# They claim it's set "automatically when --platform is provided."
+	# Lies.
+	# Maybe that's a buildx feature, because build doesn't. So we need to manually inject it.
+	BA_FLAGS+=(
+		"--build-arg=TARGETOS=${OS}"
+		"--build-arg=TARGETARCH=${PLATFORM#*/}"
+	)
 fi
 
 TARBALL_PATH="$PWD/$TARBALL_NAME"
@@ -68,31 +84,31 @@ REDHAT_TARBALL_PATH="$PWD/$REDHAT_TARBALL_NAME"
 
 cd "$WORKDIR"
 
-
 echo "==> Building image with tags:"
 for T in "${ALL_TAGS[@]}"; do
-  echo "    - $T"
+	echo "    - $T"
 done
 
 if [[ "$OS" == "linux" ]]; then
-docker buildx create --use
-docker buildx build --load \
-  --target "$TARGET" \
-  --platform "$PLATFORM" \
-  "${TAG_FLAGS[@]}" \
-  "${BA_FLAGS[@]}" \
-  -f "$DOCKERFILE" \
-  .
+	docker buildx create --use
+	docker buildx build --load \
+		--target "$TARGET" \
+		--platform "$PLATFORM" \
+		"${TAG_FLAGS[@]}" \
+		"${BA_FLAGS[@]}" \
+		-f "$DOCKERFILE" \
+		.
 else
-  (set -x;
-  docker build \
-  --target "$TARGET" \
-  --platform "$PLATFORM" \
-  "${TAG_FLAGS[@]}" \
-  "${BA_FLAGS[@]}" \
-  -f "$DOCKERFILE" \
-  .
-  )
+	(
+		set -x
+		docker build \
+			--target "$TARGET" \
+			--platform "$PLATFORM" \
+			"${TAG_FLAGS[@]}" \
+			"${BA_FLAGS[@]}" \
+			-f "$DOCKERFILE" \
+			.
+	)
 fi
 
 # validate version label is set to the correct value

--- a/scripts/docker_build.bats
+++ b/scripts/docker_build.bats
@@ -35,6 +35,8 @@ set_all_optional_env_vars() {
 	export DEV_TARBALL_NAME=blahblah.docker.dev.tar
 	export REDHAT_TARBALL_NAME=blahblah.docker.redhat.tar
 	export DEV_TAGS=""
+	export EXTRA_BUILD_ARGS=""
+	export OS=""
 }
 
 set_all_env_vars() {
@@ -67,6 +69,16 @@ set_test_dev_tags() {
 		$DEV_TAG1
 		$DEV_TAG2
 	"
+}
+
+set_test_extra_build_args() {
+    EXTRA_BUILD_ARG1="FOO=foo"
+    EXTRA_BUILD_ARG2="BAR=bar"
+
+    export EXTRA_BUILD_ARGS="
+        $EXTRA_BUILD_ARG1
+        $EXTRA_BUILD_ARG2
+    "
 }
 
 @test "only prod tags set - all prod and staging tags built" {
@@ -141,3 +153,23 @@ exercise_docker_build_script() {
 	run exercise_docker_build_script
 	[ $status -eq 1 ]
 }
+
+@test "build with extra args" {
+	set_test_prod_tags
+	set_test_extra_build_args
+	export DOCKERFILE=extra_build_args.Dockerfile
+	run exercise_docker_build_script
+    [[ "$output" =~ "--build-arg=FOO=foo" ]]
+    [[ "$output" =~ "--build-arg=BAR=bar" ]]
+	[ $status -eq 0 ]
+}
+
+@test "build with missing extra args" {
+	set_test_prod_tags
+	export DOCKERFILE=extra_build_args.Dockerfile
+	run exercise_docker_build_script
+    [[ "$output" =~ "FOO not set" ]]
+	[ $status -eq 1 ]
+}
+
+

--- a/scripts/testdata/input/extra_build_args.Dockerfile
+++ b/scripts/testdata/input/extra_build_args.Dockerfile
@@ -1,0 +1,27 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+FROM alpine:latest AS default
+
+ARG FOO
+ARG BAR
+ARG BIN_NAME
+# Export BIN_NAME for the CMD below, it can't see ARGs directly.
+ENV BIN_NAME=$BIN_NAME
+ARG PRODUCT_VERSION
+ARG PRODUCT_REVISION
+ARG PRODUCT_NAME=$BIN_NAME
+# TARGETOS and TARGETARCH are set automatically when --platform is provided.
+ARG TARGETOS TARGETARCH
+
+LABEL maintainer="Team RelEng <team-rel-eng@hashicorp.com>"
+LABEL version=$PRODUCT_VERSION
+LABEL revision=$PRODUCT_REVISION
+
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
+
+# Fail if FOO is not set
+RUN test -n "$FOO" || (echo "FOO not set" && false)
+
+USER 100
+CMD ["/bin/$BIN_NAME", "default"]
+


### PR DESCRIPTION
### Justification

In Consul-land, we are simplifying our repos and making it so that we only need to change the go version (`.go-version`) in one location when upgrading and it gets passed through to all the files that need it. One of the files that often needs this is the Dockerfile. In order to set the go version we need support for [docker build args](https://docs.docker.com/build/guide/build-args/) and thus it is needed in action-docker-build.

### Summary

I've added an optional input named `extra_build_args` that is similar in use to the `tags` input in that it is a newline separated list of values.

I've added bats tests to make sure that the build arguments make it to the docker build step (see FOO/BAR args).

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [x] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_