### PR TITLE
Add support for extra build args

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ you must call it multiple times in order to build multiple architectures.
   - PUSH_AUTO_DEV_TAGS=false/empty & dev-tags defined: push non-default dev tags
 - **`smoke_test`** allows specifying a script to run immediately after the image
   is built, to perform some basic checks on the image. See note on `smoke_test` below.
+- `extra_build_args` is a newline-separated list of extra build args to pass
+  to `docker build`. (optional)
 
 #### Note on `target`
 

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,12 @@ inputs:
     description: Tag to determine whether to push default dev tags (optional).
     default: "false"
 
+  extra_build_args:
+    description: >
+      Whitespace-separated list of extra build arguments that get passed to docker 
+      build (optional).
+    default: ""
+
   # Escape hatch inputs (use sparingly if at all).
   workdir:
     description: Working directory in which to run 'docker build'.

--- a/scripts/digest_inputs
+++ b/scripts/digest_inputs
@@ -33,6 +33,7 @@ TAGS="${TAGS:-}"
 REDHAT_TAG="${REDHAT_TAG:-}"
 PUSH_AUTO_DEV_TAGS="${PUSH_AUTO_DEV_TAGS:=false}"
 OS_VERSION="${OS_VERSION:-}"
+EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS:-}"
 
 # Strip version to MAJOR.MINOR
 get_minor_version() {
@@ -208,3 +209,7 @@ fi
 add_var PLATFORM
 
 add_var MINOR
+
+if [ -n "$EXTRA_BUILD_ARGS" ]; then
+  add_var EXTRA_BUILD_ARGS
+fi

--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -22,6 +22,7 @@ WORKDIR="${WORKDIR:-.}"
 
 export DEV_TAGS="${DEV_TAGS:-}"
 export REDHAT_TAG="${REDHAT_TAG:-}"
+export EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS:-}"
 
 # Convert all contiguous blocks of whitespace to single spaces using xargs.
 # This is needed to get all tags on one line for the read -ra below.
@@ -51,6 +52,19 @@ BUILD_ARGS+=("PRODUCT_REVISION=$REVISION")
 for B in "${BUILD_ARGS[@]}"; do
 	BA_FLAGS+=("--build-arg=$B")
 done
+
+# Append any extra build args to the final list of build args.
+if [ -n "$EXTRA_BUILD_ARGS" ]; then
+  # Convert all contiguous blocks of whitespace to single spaces using xargs.
+  # This is needed to get all tags on one line for the read -ra below.
+  EXTRA_BUILD_ARGS="$(xargs <<<"$EXTRA_BUILD_ARGS")"
+
+  read -ra EXTRA_BUILD_ARGS_A <<<"$EXTRA_BUILD_ARGS"
+  for E in "${EXTRA_BUILD_ARGS_A[@]}"; do
+    BA_FLAGS+=("--build-arg=$E")
+  done
+fi
+
 if [[ "$OS" == "windows" ]]; then
   # Warning: Our Dockerfiles refer to TARGETOS and TARGETARCH.
   # They claim it's set "automatically when --platform is provided."

--- a/scripts/docker_build.bats
+++ b/scripts/docker_build.bats
@@ -35,6 +35,8 @@ set_all_optional_env_vars() {
 	export DEV_TARBALL_NAME=blahblah.docker.dev.tar
 	export REDHAT_TARBALL_NAME=blahblah.docker.redhat.tar
 	export DEV_TAGS=""
+	export EXTRA_BUILD_ARGS=""
+	export OS=""
 }
 
 set_all_env_vars() {
@@ -67,6 +69,16 @@ set_test_dev_tags() {
 		$DEV_TAG1
 		$DEV_TAG2
 	"
+}
+
+set_test_extra_build_args() {
+    EXTRA_BUILD_ARG1="FOO=foo"
+    EXTRA_BUILD_ARG2="BAR=bar"
+
+    export EXTRA_BUILD_ARGS="
+        $EXTRA_BUILD_ARG1
+        $EXTRA_BUILD_ARG2
+    "
 }
 
 @test "only prod tags set - all prod and staging tags built" {
@@ -141,3 +153,23 @@ exercise_docker_build_script() {
 	run exercise_docker_build_script
 	[ $status -eq 1 ]
 }
+
+@test "build with extra args" {
+	set_test_prod_tags
+	set_test_extra_build_args
+	export DOCKERFILE=extra_build_args.Dockerfile
+	run exercise_docker_build_script
+    [[ "$output" =~ "--build-arg=FOO=foo" ]]
+    [[ "$output" =~ "--build-arg=BAR=bar" ]]
+	[ $status -eq 0 ]
+}
+
+@test "build with missing extra args" {
+	set_test_prod_tags
+	export DOCKERFILE=extra_build_args.Dockerfile
+	run exercise_docker_build_script
+    [[ "$output" =~ "FOO not set" ]]
+	[ $status -eq 1 ]
+}
+
+

--- a/scripts/testdata/input/extra_build_args.Dockerfile
+++ b/scripts/testdata/input/extra_build_args.Dockerfile
@@ -1,0 +1,27 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+FROM alpine:latest AS default
+
+ARG FOO
+ARG BAR
+ARG BIN_NAME
+# Export BIN_NAME for the CMD below, it can't see ARGs directly.
+ENV BIN_NAME=$BIN_NAME
+ARG PRODUCT_VERSION
+ARG PRODUCT_REVISION
+ARG PRODUCT_NAME=$BIN_NAME
+# TARGETOS and TARGETARCH are set automatically when --platform is provided.
+ARG TARGETOS TARGETARCH
+
+LABEL maintainer="Team RelEng <team-rel-eng@hashicorp.com>"
+LABEL version=$PRODUCT_VERSION
+LABEL revision=$PRODUCT_REVISION
+
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
+
+# Fail if FOO is not set
+RUN test -n "$FOO" || (echo "FOO not set" && false)
+
+USER 100
+CMD ["/bin/$BIN_NAME", "default"]
+


### PR DESCRIPTION
#### Justification

In Consul-land, we are simplifying our repos and making it so that we only need to change the go version (`.go-version`) in one location when upgrading and it gets passed through to all the files that need it. One of the files that often needs this is the Dockerfile. In order to set the go version we need support for [docker build args](https://docs.docker.com/build/guide/build-args/) and thus it is needed in action-docker-build.

### Summary

I've added an optional input named `extra_build_args` that is similar in use to the `tags` input in that it is a newline separated list of values.

I've added bats tests to make sure that the build arguments make it to the docker build step (see FOO/BAR args).

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [x] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_