### PR TITLE
use tsccr-helper to update actions

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           go build -o "$product_name" .
           zip "${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip" "$product_name"
-      - name: Upload product artifact.
+      - name: Upload product artifact-${{ env.product_name }}-${{ env.version }}-${{ matrix.goos }}-${{ matrix.goarch }}-${{ github.job }}
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           path: example/${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -28,7 +28,7 @@ jobs:
           - { go: "1.16", goos: "solaris", goarch: "amd64" }
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Setup go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
@@ -41,7 +41,7 @@ jobs:
           go build -o "$product_name" .
           zip "${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip" "$product_name"
       - name: Upload product artifact
-        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           path: example/${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           name: ${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
@@ -62,7 +62,7 @@ jobs:
           - { arch: "arm64" }
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Build
         # To run the example with the current commit use 'uses: ./'
         uses: ./

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -28,9 +28,9 @@ jobs:
           - { go: "1.16", goos: "solaris", goarch: "amd64" }
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Setup go
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ matrix.go }}
       - name: Compile Binary
@@ -41,7 +41,7 @@ jobs:
           go build -o "$product_name" .
           zip "${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip" "$product_name"
       - name: Upload product artifact.
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           path: example/${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           name: ${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
@@ -62,7 +62,7 @@ jobs:
           - { arch: "arm64" }
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Build
         # To run the example with the current commit use 'uses: ./'
         uses: ./

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -70,7 +70,7 @@ jobs:
         # 'uses: hashicorp/actions-docker-build@v1'
         with:
           version: 1.0.0
-          target: default-${{ strategy.job-index }}
+          target: default
           arch: ${{ matrix.arch }}
           # Production tags. (These are the tags used for the multi-arch images
           # we eventually push, they must never be architecture/platform-specific.)

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -70,7 +70,7 @@ jobs:
         # 'uses: hashicorp/actions-docker-build@v1'
         with:
           version: 1.0.0
-          target: default
+          target: default-${{ strategy.job-index }}
           arch: ${{ matrix.arch }}
           # Production tags. (These are the tags used for the multi-arch images
           # we eventually push, they must never be architecture/platform-specific.)

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           go build -o "$product_name" .
           zip "${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip" "$product_name"
-      - name: Upload product artifact-${{ env.product_name }}-${{ env.version }}-${{ matrix.goos }}-${{ matrix.goarch }}-${{ github.job }}
+      - name: Upload product artifact-${{ env.product_name }}-${{ env.version }}-${{ matrix.goos }}-${{ matrix.goarch }}-${{ github.run_id }}
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           path: example/${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Build
+      - name: Build-${{ env.product_name }}-${{ env.version }}-${{ matrix.arch }}-${{ github.run_id }}
         # To run the example with the current commit use 'uses: ./'
         uses: ./
         # For real usages, you will reference the action like this:

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           go build -o "$product_name" .
           zip "${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip" "$product_name"
-      - name: Upload product artifact-${{ env.product_name }}-${{ env.version }}-${{ matrix.goos }}-${{ matrix.goarch }}-${{ github.run_id }}
+      - name: Upload product artifact
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           path: example/${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Build-${{ env.product_name }}-${{ env.version }}-${{ matrix.arch }}-${{ github.run_id }}
+      - name: Build
         # To run the example with the current commit use 'uses: ./'
         uses: ./
         # For real usages, you will reference the action like this:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,12 @@ jobs:
         run: |
           zip ./testdata/test_bin.zip ./testdata/test_bin
           zip ./testdata/actions-docker-build.zip ./testdata/actions-docker-build
-      - name: Upload test artifacts-${{ github.job }}
+      - name: Upload test artifacts
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           path: testdata/test_bin.zip
           name: test_bin.zip
-      - name: Upload a test artifact-${{ github.job }}
+      - name: Upload a test artifact
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           path: testdata/actions-docker-build.zip
@@ -66,7 +66,7 @@ jobs:
           tags: |
             ${{env.TAG_PREFIX}}/action-test-dockerfile-in-root:tag1
             ${{env.TAG_PREFIX}}/action-test-dockerfile-in-root:tag2
-          zip_artifact_name: test_bin.zip
+          zip_artifact_name: test_bin-${{ env.OVERRIDE_TARBALL_NAME }}.zip
           bin_name: test_bin
           # No overrides to Dockerfile path.
       - name: Assert Tarball Created And Contains Correct Tags
@@ -93,7 +93,7 @@ jobs:
           tags: |
             ${{env.TAG_PREFIX}}/action-test-setting-dockerfile:tag1
             ${{env.TAG_PREFIX}}/action-test-setting-dockerfile:tag2
-          zip_artifact_name: test_bin.zip
+          zip_artifact_name: test_bin-${{ env.OVERRIDE_TARBALL_NAME }}.zip
           bin_name: test_bin
           # Test setting just dockerfile.
           dockerfile: testdata/Dockerfile
@@ -121,7 +121,7 @@ jobs:
           tags: |
             ${{env.TAG_PREFIX}}/action-test-setting-workdir:tag1
             ${{env.TAG_PREFIX}}/action-test-setting-workdir:tag2
-          zip_artifact_name: test_bin.zip
+          zip_artifact_name: test_bin-${{ env.OVERRIDE_TARBALL_NAME }}.zip
           bin_name: test_bin
           # Test setting just workdir.
           workdir: testdata
@@ -149,7 +149,7 @@ jobs:
           tags: |
             ${{env.TAG_PREFIX}}/action-test-smoke-test-pass:tag1
             ${{env.TAG_PREFIX}}/action-test-smoke-test-pass:tag2
-          zip_artifact_name: test_bin.zip
+          zip_artifact_name: test_bin-${{ env.OVERRIDE_TARBALL_NAME }}.zip
           bin_name: test_bin
           dockerfile: testdata/Dockerfile
           #test smoke test. This should pass
@@ -175,7 +175,7 @@ jobs:
           tags: |
             ${{env.TAG_PREFIX}}/action-test-smoke-test-fail:tag1
             ${{env.TAG_PREFIX}}/action-test-smoke-test-fail:tag2
-          zip_artifact_name: test_bin.zip
+          zip_artifact_name: test_bin-${{ env.OVERRIDE_TARBALL_NAME }}.zip
           bin_name: test_bin
           dockerfile: testdata/Dockerfile
           # Test smoke test failure
@@ -255,7 +255,9 @@ jobs:
         uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
           path: archive
-          name: actions-docker-build.zip
+          pattern: archive-*
+          name: actions-docker-build-${{ github.run_id }}.zip
+          merge-multiple: true
       # Construct the custom context,
       # This is "required" because normally our extraction process puts the artifacts in deeply nested
       # `dist/$TARGETOS/$TARGETARCH/$BIN_NAME` paths.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           sudo git clone --depth 1 --branch "v$BATS_VERSION" "$BATS_REPO" "$BATS_PATH"
           echo "$BATS_PATH/bin" >> "$GITHUB_PATH"
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Run BATS tests
         run: make test
 
@@ -27,18 +27,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Zip Test Bin
         run: |
           zip ./testdata/test_bin.zip ./testdata/test_bin
           zip ./testdata/actions-docker-build.zip ./testdata/actions-docker-build
       - name: Upload test artifacts
-        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           path: testdata/test_bin.zip
           name: test_bin.zip
       - name: Upload a test artifact
-        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           path: testdata/actions-docker-build.zip
           name: actions-docker-build.zip
@@ -51,7 +51,7 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       # Test setup.
       - name: Move Dockerfile to Repo Root
         run: |
@@ -83,7 +83,7 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Invoke Action
         uses: ./ # This is the action we're testing.
         with:
@@ -111,7 +111,7 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Invoke Action
         uses: ./ # This is the action we're testing.
         with:
@@ -139,7 +139,7 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Invoke Action
         uses: ./
         with:
@@ -164,7 +164,7 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Invoke Action
         id: docker-build
         uses: ./
@@ -202,7 +202,7 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       # Test setup.
       - name: Move Dockerfile to Repo Root
         run: |
@@ -228,7 +228,7 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       # Test setup
       - name: Move Dockerfile to Repo Root
         run: |
@@ -249,10 +249,10 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       # Handle the artifact download ourselves
       - name: Download Product Zip Artifact
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: archive
           pattern: archive-*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,7 +256,7 @@ jobs:
         with:
           path: archive
           pattern: archive-*
-          name: actions-docker-build-${{ github.run_id }}.zip
+          name: actions-docker-build.zip
           merge-multiple: true
       # Construct the custom context,
       # This is "required" because normally our extraction process puts the artifacts in deeply nested
@@ -272,6 +272,7 @@ jobs:
         with:
           version: 1.0.0
           target: default
+          id: opt-out-extract
           arch: amd64
           do_zip_extract_step: false
           workdir: ./my-context-dir

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
           tags: |
             ${{env.TAG_PREFIX}}/action-test-dockerfile-in-root:tag1
             ${{env.TAG_PREFIX}}/action-test-dockerfile-in-root:tag2
-          zip_artifact_name: test_bin-${{ env.OVERRIDE_TARBALL_NAME }}.zip
+          zip_artifact_name: test_bin.zip
           bin_name: test_bin
           # No overrides to Dockerfile path.
       - name: Assert Tarball Created And Contains Correct Tags
@@ -93,7 +93,7 @@ jobs:
           tags: |
             ${{env.TAG_PREFIX}}/action-test-setting-dockerfile:tag1
             ${{env.TAG_PREFIX}}/action-test-setting-dockerfile:tag2
-          zip_artifact_name: test_bin-${{ env.OVERRIDE_TARBALL_NAME }}.zip
+          zip_artifact_name: test_bin.zip
           bin_name: test_bin
           # Test setting just dockerfile.
           dockerfile: testdata/Dockerfile
@@ -121,7 +121,7 @@ jobs:
           tags: |
             ${{env.TAG_PREFIX}}/action-test-setting-workdir:tag1
             ${{env.TAG_PREFIX}}/action-test-setting-workdir:tag2
-          zip_artifact_name: test_bin-${{ env.OVERRIDE_TARBALL_NAME }}.zip
+          zip_artifact_name: test_bin.zip
           bin_name: test_bin
           # Test setting just workdir.
           workdir: testdata
@@ -149,7 +149,7 @@ jobs:
           tags: |
             ${{env.TAG_PREFIX}}/action-test-smoke-test-pass:tag1
             ${{env.TAG_PREFIX}}/action-test-smoke-test-pass:tag2
-          zip_artifact_name: test_bin-${{ env.OVERRIDE_TARBALL_NAME }}.zip
+          zip_artifact_name: test_bin.zip
           bin_name: test_bin
           dockerfile: testdata/Dockerfile
           #test smoke test. This should pass
@@ -175,7 +175,7 @@ jobs:
           tags: |
             ${{env.TAG_PREFIX}}/action-test-smoke-test-fail:tag1
             ${{env.TAG_PREFIX}}/action-test-smoke-test-fail:tag2
-          zip_artifact_name: test_bin-${{ env.OVERRIDE_TARBALL_NAME }}.zip
+          zip_artifact_name: test_bin.zip
           bin_name: test_bin
           dockerfile: testdata/Dockerfile
           # Test smoke test failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,12 @@ jobs:
         run: |
           zip ./testdata/test_bin.zip ./testdata/test_bin
           zip ./testdata/actions-docker-build.zip ./testdata/actions-docker-build
-      - name: Upload test artifacts
+      - name: Upload test artifacts-${{ github.job }}
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           path: testdata/test_bin.zip
           name: test_bin.zip
-      - name: Upload a test artifact.
+      - name: Upload a test artifact-${{ github.job }}
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           path: testdata/actions-docker-build.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
         uses: ./ # This is the action we're testing.
         with:
           version: 1.0.0
-          target: default
+          target: default-dockerfile-in-root
           arch: amd64
           tags: |
             ${{env.TAG_PREFIX}}/action-test-dockerfile-in-root:tag1
@@ -88,7 +88,7 @@ jobs:
         uses: ./ # This is the action we're testing.
         with:
           version: 1.0.0
-          target: default
+          target: default-setting-dockerfile
           arch: amd64
           tags: |
             ${{env.TAG_PREFIX}}/action-test-setting-dockerfile:tag1
@@ -116,7 +116,7 @@ jobs:
         uses: ./ # This is the action we're testing.
         with:
           version: 1.0.0
-          target: default
+          target: default-setting-workdir
           arch: amd64
           tags: |
             ${{env.TAG_PREFIX}}/action-test-setting-workdir:tag1
@@ -144,7 +144,7 @@ jobs:
         uses: ./
         with:
           version: 1.0.0
-          target: default
+          target: default-smoke-test-pass
           arch: amd64
           tags: |
             ${{env.TAG_PREFIX}}/action-test-smoke-test-pass:tag1
@@ -170,7 +170,7 @@ jobs:
         uses: ./
         with:
           version: 1.0.0
-          target: default
+          target: default-smoke-test-fail
           arch: amd64
           tags: |
             ${{env.TAG_PREFIX}}/action-test-smoke-test-fail:tag1
@@ -212,7 +212,7 @@ jobs:
         uses: ./ # This is the action we're testing.
         with:
           version: 1.0.0
-          target: default
+          target: default-redhat-tag-only
           arch: amd64
           redhat_tag: ${{env.TEST_REDHAT_TAG}}
           zip_artifact_name: test_bin.zip
@@ -237,7 +237,7 @@ jobs:
         uses: ./
         with:
           version: 1.0.0
-          target: default
+          target: default-guessed-bin-name
           arch: amd64
           zip_artifact_name: actions-docker-build.zip
           #bin_name: actions-docker-build # (which matches the $reponame)
@@ -271,7 +271,7 @@ jobs:
         uses: ./
         with:
           version: 1.0.0
-          target: default
+          target: default-opt-out-extract
           id: opt-out-extract
           arch: amd64
           do_zip_extract_step: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           sudo git clone --depth 1 --branch "v$BATS_VERSION" "$BATS_REPO" "$BATS_PATH"
           echo "$BATS_PATH/bin" >> "$GITHUB_PATH"
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run BATS tests
         run: make test
 
@@ -27,18 +27,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Zip Test Bin
         run: |
           zip ./testdata/test_bin.zip ./testdata/test_bin
           zip ./testdata/actions-docker-build.zip ./testdata/actions-docker-build
       - name: Upload a test artifact.
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           path: testdata/test_bin.zip
           name: test_bin.zip
       - name: Upload a test artifact.
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           path: testdata/actions-docker-build.zip
           name: actions-docker-build.zip
@@ -51,7 +51,7 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       # Test setup.
       - name: Move Dockerfile to Repo Root
         run: |
@@ -83,7 +83,7 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Invoke Action
         uses: ./ # This is the action we're testing.
         with:
@@ -111,7 +111,7 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Invoke Action
         uses: ./ # This is the action we're testing.
         with:
@@ -139,7 +139,7 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Invoke Action
         uses: ./
         with:
@@ -164,7 +164,7 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Invoke Action
         id: docker-build
         uses: ./
@@ -202,7 +202,7 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       # Test setup.
       - name: Move Dockerfile to Repo Root
         run: |
@@ -228,7 +228,7 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       # Test setup
       - name: Move Dockerfile to Repo Root
         run: |
@@ -249,10 +249,10 @@ jobs:
       - action-test-prep
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       # Handle the artifact download ourselves
       - name: Download Product Zip Artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
           path: archive
           name: actions-docker-build.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           zip ./testdata/test_bin.zip ./testdata/test_bin
           zip ./testdata/actions-docker-build.zip ./testdata/actions-docker-build
-      - name: Upload a test artifact.
+      - name: Upload test artifacts
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           path: testdata/test_bin.zip

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ jobs:
         run: |
           go build -o "$product_name" .
           zip "${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip" "$product_name"
-      - name: Upload product artifact.
+      - name: Upload product artifacts
         uses: actions/upload-artifact@v2
         with:
           path: example/${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ jobs:
           go build -o "$product_name" .
           zip "${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip" "$product_name"
       - name: Upload product artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: example/${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           name: ${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip

--- a/action.yml
+++ b/action.yml
@@ -214,35 +214,39 @@ runs:
       run: $GITHUB_ACTION_PATH/scripts/create_metadata
 
     - name: Upload Docker Image metadata
+      id: docker-image-metadata
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       env:
         # Add _redhat if this is a redhat call.
         REDHAT_SUFFIX: ${{ inputs.redhat_tag && '_redhat' || '' }}
       with:
-        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}-${{ inputs.arch }}
+        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}-${{ matrix.id }}
         path: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.json
         if-no-files-found: error
 
     - name: Upload Prod Tarball
+      id: prod-tarball
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.TAGS != '' }}
       with:
-        name: ${{ env.TARBALL_NAME }}-${{ inputs.arch }}
+        name: ${{ env.TARBALL_NAME }}-${{ matrix.id }}
         path: ${{ env.TARBALL_NAME }}
         if-no-files-found: error
 
     - name: Upload Dev Tarball
+      id: dev-tarball
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.DEV_TAGS != '' }}
       with:
-        name: ${{ env.DEV_TARBALL_NAME }}-${{ inputs.arch }}
+        name: ${{ env.DEV_TARBALL_NAME }}-${{ matrix.id }}
         path: ${{ env.DEV_TARBALL_NAME }}
         if-no-files-found: error
 
     - name: Upload Red Hat Tarball
+      id: redhat-tarball
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.REDHAT_TAG != '' }}
       with:
-        name: ${{ env.REDHAT_TARBALL_NAME }}-${{ inputs.arch }}
+        name: ${{ env.REDHAT_TARBALL_NAME }}-${{ matrix.id }}
         path: ${{ env.REDHAT_TARBALL_NAME }}
         if-no-files-found: error

--- a/action.yml
+++ b/action.yml
@@ -213,40 +213,36 @@ runs:
       shell: bash
       run: $GITHUB_ACTION_PATH/scripts/create_metadata
 
-    - name: Upload Docker Image metadata
-      id: docker-image-metadata
+    - name: docker-image-metadata
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       env:
         # Add _redhat if this is a redhat call.
         REDHAT_SUFFIX: ${{ inputs.redhat_tag && '_redhat' || '' }}
       with:
-        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}-${{ matrix.id }}
+        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}-${{ github.job }}
         path: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.json
         if-no-files-found: error
 
-    - name: Upload Prod Tarball
-      id: prod-tarball
+    - name: prod-tarball
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.TAGS != '' }}
       with:
-        name: ${{ env.TARBALL_NAME }}-${{ matrix.id }}
+        name: ${{ env.TARBALL_NAME }}-${{ github.job }}
         path: ${{ env.TARBALL_NAME }}
         if-no-files-found: error
 
-    - name: Upload Dev Tarball
-      id: dev-tarball
+    - name: dev-tarball
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.DEV_TAGS != '' }}
       with:
-        name: ${{ env.DEV_TARBALL_NAME }}-${{ matrix.id }}
+        name: ${{ env.DEV_TARBALL_NAME }}-${{ github.job}}
         path: ${{ env.DEV_TARBALL_NAME }}
         if-no-files-found: error
 
-    - name: Upload Red Hat Tarball
-      id: redhat-tarball
+    - name: redhat-tarball
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.REDHAT_TAG != '' }}
       with:
-        name: ${{ env.REDHAT_TARBALL_NAME }}-${{ matrix.id }}
+        name: ${{ env.REDHAT_TARBALL_NAME }}-${{ github.job }}
         path: ${{ env.REDHAT_TARBALL_NAME }}
         if-no-files-found: error

--- a/action.yml
+++ b/action.yml
@@ -225,7 +225,7 @@ runs:
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.TAGS != '' }}
       with:
-        name: ${{ env.TARBALL_NAME }}
+        name: ${{ env.TARBALL_NAME }}-*
         path: ${{ env.TARBALL_NAME }}
         if-no-files-found: error
 
@@ -233,7 +233,7 @@ runs:
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.DEV_TAGS != '' }}
       with:
-        name: ${{ env.DEV_TARBALL_NAME }}
+        name: ${{ env.DEV_TARBALL_NAME }}-*
         path: ${{ env.DEV_TARBALL_NAME }}
         if-no-files-found: error
 
@@ -241,6 +241,6 @@ runs:
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.REDHAT_TAG != '' }}
       with:
-        name: ${{ env.REDHAT_TARBALL_NAME }}
+        name: ${{ env.REDHAT_TARBALL_NAME }}-*
         path: ${{ env.REDHAT_TARBALL_NAME }}
         if-no-files-found: error

--- a/action.yml
+++ b/action.yml
@@ -187,7 +187,9 @@ runs:
       if: ${{ inputs.do_zip_extract_step == 'true'  }}
       with:
         path: ${{ env.ZIP_LOCATION }}
+        pattern: ${{ env.ZIP_LOCATION }}-*
         name: ${{ env.ZIP_NAME }}
+        merge-multiple: true
 
     - name: Extract Product Zip Artifact
       if: ${{ inputs.do_zip_extract_step == 'true' }}
@@ -217,7 +219,7 @@ runs:
         # Add _redhat if this is a redhat call.
         REDHAT_SUFFIX: ${{ inputs.redhat_tag && '_redhat' || '' }}
       with:
-        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.json
+        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}-${{ inputs.arch }}
         path: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.json
         if-no-files-found: error
 
@@ -225,7 +227,7 @@ runs:
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.TAGS != '' }}
       with:
-        name: ${{ env.TARBALL_NAME }}
+        name: ${{ env.TARBALL_NAME }}-${{ inputs.arch }}
         path: ${{ env.TARBALL_NAME }}
         if-no-files-found: error
 
@@ -233,7 +235,7 @@ runs:
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.DEV_TAGS != '' }}
       with:
-        name: ${{ env.DEV_TARBALL_NAME }}
+        name: ${{ env.DEV_TARBALL_NAME }}-${{ inputs.arch }}
         path: ${{ env.DEV_TARBALL_NAME }}
         if-no-files-found: error
 
@@ -241,6 +243,6 @@ runs:
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.REDHAT_TAG != '' }}
       with:
-        name: ${{ env.REDHAT_TARBALL_NAME }}
+        name: ${{ env.REDHAT_TARBALL_NAME }}-${{ inputs.arch }}
         path: ${{ env.REDHAT_TARBALL_NAME }}
         if-no-files-found: error

--- a/action.yml
+++ b/action.yml
@@ -220,7 +220,7 @@ runs:
         # Add _redhat if this is a redhat call.
         REDHAT_SUFFIX: ${{ inputs.redhat_tag && '_redhat' || '' }}
       with:
-        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}-${{ steps.docker-image-metadata.outputs }}
+        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}-docker-image-metadata
         path: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.json
         if-no-files-found: error
 
@@ -229,7 +229,7 @@ runs:
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.TAGS != '' }}
       with:
-        name: ${{ env.TARBALL_NAME }}-${{ steps.prod-tarball.outputs }}
+        name: ${{ env.TARBALL_NAME }}-prod-tarball
         path: ${{ env.TARBALL_NAME }}
         if-no-files-found: error
 
@@ -238,7 +238,7 @@ runs:
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.DEV_TAGS != '' }}
       with:
-        name: ${{ env.DEV_TARBALL_NAME }}-${{ steps.dev-tarball.outputs }}
+        name: ${{ env.DEV_TARBALL_NAME }}-dev-tarball
         path: ${{ env.DEV_TARBALL_NAME }}
         if-no-files-found: error
 
@@ -247,6 +247,6 @@ runs:
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.REDHAT_TAG != '' }}
       with:
-        name: ${{ env.REDHAT_TARBALL_NAME }}-${{ steps.redhat-tarball.outputs }}
+        name: ${{ env.REDHAT_TARBALL_NAME }}-redhat-tarball
         path: ${{ env.REDHAT_TARBALL_NAME }}
         if-no-files-found: error

--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
       run: $GITHUB_ACTION_PATH/scripts/register_qemu_binfmt
 
     - name: Download Product Zip Artifact
-      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
       if: ${{ inputs.do_zip_extract_step == 'true'  }}
       with:
         path: ${{ env.ZIP_LOCATION }}
@@ -214,7 +214,7 @@ runs:
       run: $GITHUB_ACTION_PATH/scripts/create_metadata
 
     - name: Upload Docker Image metadata
-      uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       env:
         # Add _redhat if this is a redhat call.
         REDHAT_SUFFIX: ${{ inputs.redhat_tag && '_redhat' || '' }}
@@ -224,7 +224,7 @@ runs:
         if-no-files-found: error
 
     - name: Upload Prod Tarball
-      uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       if: ${{ env.TAGS != '' }}
       with:
         name: ${{ env.TARBALL_NAME }}-prod-tarball
@@ -232,7 +232,7 @@ runs:
         if-no-files-found: error
 
     - name: Upload Dev Tarball
-      uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       if: ${{ env.DEV_TAGS != '' }}
       with:
         name: ${{ env.DEV_TARBALL_NAME }}-dev-tarball
@@ -240,7 +240,7 @@ runs:
         if-no-files-found: error
 
     - name: Upload Red Hat Tarball
-      uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       if: ${{ env.REDHAT_TAG != '' }}
       with:
         name: ${{ env.REDHAT_TARBALL_NAME }}-redhat-tarball

--- a/action.yml
+++ b/action.yml
@@ -214,18 +214,16 @@ runs:
       run: $GITHUB_ACTION_PATH/scripts/create_metadata
 
     - name: Upload Docker Image metadata
-      id: docker-image-metadata
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       env:
         # Add _redhat if this is a redhat call.
         REDHAT_SUFFIX: ${{ inputs.redhat_tag && '_redhat' || '' }}
       with:
-        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}-docker-image-metadata
+        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}-${{ inputs.arch }}
         path: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.json
         if-no-files-found: error
 
     - name: Upload Prod Tarball
-      id: prod-tarball
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.TAGS != '' }}
       with:
@@ -234,7 +232,6 @@ runs:
         if-no-files-found: error
 
     - name: Upload Dev Tarball
-      id: dev-tarball
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.DEV_TAGS != '' }}
       with:
@@ -243,7 +240,6 @@ runs:
         if-no-files-found: error
 
     - name: Upload Red Hat Tarball
-      id: redhat-tarball
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.REDHAT_TAG != '' }}
       with:

--- a/action.yml
+++ b/action.yml
@@ -225,7 +225,7 @@ runs:
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.TAGS != '' }}
       with:
-        name: ${{ env.TARBALL_NAME }}-*
+        name: ${{ env.TARBALL_NAME }}
         path: ${{ env.TARBALL_NAME }}
         if-no-files-found: error
 
@@ -233,7 +233,7 @@ runs:
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.DEV_TAGS != '' }}
       with:
-        name: ${{ env.DEV_TARBALL_NAME }}-*
+        name: ${{ env.DEV_TARBALL_NAME }}
         path: ${{ env.DEV_TARBALL_NAME }}
         if-no-files-found: error
 
@@ -241,6 +241,6 @@ runs:
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.REDHAT_TAG != '' }}
       with:
-        name: ${{ env.REDHAT_TARBALL_NAME }}-*
+        name: ${{ env.REDHAT_TARBALL_NAME }}
         path: ${{ env.REDHAT_TARBALL_NAME }}
         if-no-files-found: error

--- a/action.yml
+++ b/action.yml
@@ -219,7 +219,7 @@ runs:
         # Add _redhat if this is a redhat call.
         REDHAT_SUFFIX: ${{ inputs.redhat_tag && '_redhat' || '' }}
       with:
-        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}-${{ inputs.arch }}
+        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}-${{ strategy.job-index }}
         path: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.json
         if-no-files-found: error
 

--- a/action.yml
+++ b/action.yml
@@ -213,36 +213,40 @@ runs:
       shell: bash
       run: $GITHUB_ACTION_PATH/scripts/create_metadata
 
-    - name: docker-image-metadata
+    - name: Upload Docker Image metadata
+      id: docker-image-metadata
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       env:
         # Add _redhat if this is a redhat call.
         REDHAT_SUFFIX: ${{ inputs.redhat_tag && '_redhat' || '' }}
       with:
-        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}-${{ github.job }}
+        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}-${{ steps.docker-image-metadata.outputs }}
         path: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.json
         if-no-files-found: error
 
-    - name: prod-tarball
+    - name: Upload Prod Tarball
+      id: prod-tarball
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.TAGS != '' }}
       with:
-        name: ${{ env.TARBALL_NAME }}-${{ github.job }}
+        name: ${{ env.TARBALL_NAME }}-${{ steps.prod-tarball.outputs }}
         path: ${{ env.TARBALL_NAME }}
         if-no-files-found: error
 
-    - name: dev-tarball
+    - name: Upload Dev Tarball
+      id: dev-tarball
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.DEV_TAGS != '' }}
       with:
-        name: ${{ env.DEV_TARBALL_NAME }}-${{ github.job}}
+        name: ${{ env.DEV_TARBALL_NAME }}-${{ steps.dev-tarball.outputs }}
         path: ${{ env.DEV_TARBALL_NAME }}
         if-no-files-found: error
 
-    - name: redhat-tarball
+    - name: Upload Red Hat Tarball
+      id: redhat-tarball
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.REDHAT_TAG != '' }}
       with:
-        name: ${{ env.REDHAT_TARBALL_NAME }}-${{ github.job }}
+        name: ${{ env.REDHAT_TARBALL_NAME }}-${{ steps.redhat-tarball.outputs }}
         path: ${{ env.REDHAT_TARBALL_NAME }}
         if-no-files-found: error

--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
       run: $GITHUB_ACTION_PATH/scripts/register_qemu_binfmt
 
     - name: Download Product Zip Artifact
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
       if: ${{ inputs.do_zip_extract_step == 'true'  }}
       with:
         path: ${{ env.ZIP_LOCATION }}
@@ -212,7 +212,7 @@ runs:
       run: $GITHUB_ACTION_PATH/scripts/create_metadata
 
     - name: Upload Docker Image metadata
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       env:
         # Add _redhat if this is a redhat call.
         REDHAT_SUFFIX: ${{ inputs.redhat_tag && '_redhat' || '' }}
@@ -222,7 +222,7 @@ runs:
         if-no-files-found: error
 
     - name: Upload Prod Tarball
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.TAGS != '' }}
       with:
         name: ${{ env.TARBALL_NAME }}
@@ -230,7 +230,7 @@ runs:
         if-no-files-found: error
 
     - name: Upload Dev Tarball
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.DEV_TAGS != '' }}
       with:
         name: ${{ env.DEV_TARBALL_NAME }}
@@ -238,7 +238,7 @@ runs:
         if-no-files-found: error
 
     - name: Upload Red Hat Tarball
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       if: ${{ env.REDHAT_TAG != '' }}
       with:
         name: ${{ env.REDHAT_TARBALL_NAME }}


### PR DESCRIPTION
### Justification

Slack Context: https://hashicorp.slack.com/archives/CR024M999/p1705501772989679
Releng Support Ticket: https://github.com/hashicorp/releng-support/issues/201

### Summary

This PR uses the tsccr-bot to help upgrade some outdated actions including download-artifact, upload-artifact, checkout, setup-go. 