### PR TITLE
Add windows to example

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -87,12 +87,12 @@ jobs:
   build-windows-image:
     needs:
       - build-product-binary
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - { arch: "amd64", Dockerfile: "Dockerfile.windows-2022" }
-          - { arch: "amd64", Dockerfile: "Dockerfile.windows-2019" }
+          - { runner: "windows-2022", arch: "amd64", Dockerfile: "Dockerfile.windows-2022" }
+          - { runner: "windows-2019", arch: "amd64", Dockerfile: "Dockerfile.windows-2019" }
+    runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,5 +1,5 @@
 name: example
-on: [push]
+on: [pull_request]
 
 env:
   product_name: actions-docker-build

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -47,7 +47,7 @@ jobs:
           name: ${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           if-no-files-found: error
 
-  build-product-docker-image:
+  build-linux-image:
     needs:
       - build-product-binary
     runs-on: ubuntu-latest
@@ -83,3 +83,37 @@ jobs:
             docker.io/hashicorppreview/${{env.product_name}}:${{env.version}}-dev
           # Usually you wouldn't need to set workdir, but this is just an example.
           workdir: example/
+
+  build-windows-image:
+    needs:
+      - build-product-binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - { arch: "amd64", Dockerfile: "Dockerfile.windows-2022" }
+          - { arch: "amd64", Dockerfile: "Dockerfile.windows-2019" }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Build
+        # To run the example with the current commit use 'uses: ./'
+        uses: ./
+        # For real usages, you will reference the action like this:
+        # 'uses: hashicorp/actions-docker-build@v1'
+        with:
+          version: 1.0.0
+          target: default
+          arch: ${{ matrix.arch }}
+          # Production tags. (These are the tags used for the multi-arch images
+          # we eventually push, they need not be architecture/platform-specific.)
+          tags: |
+            docker.io/hashicorp/${{env.product_name}}:${{env.version}}
+            public.ecr.aws/hashicorp/${{env.product_name}}:${{env.version}}
+          # Dev tags are pushed more frequently by downstream processes. They also
+          # need not reference the architecture.
+          dev_tags: |
+            docker.io/hashicorppreview/${{env.product_name}}:${{env.version}}-dev
+          # Usually you wouldn't need to set workdir, but this is just an example.
+          workdir: example/
+          Dockerfile: ${{matrix.Dockerfile}}

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 env:
   product_name: actions-docker-build
-  version: 1.0.0
+  product_version: 1.0.0
 
 defaults:
   run:
@@ -39,12 +39,12 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
         run: |
           go build -o "$product_name" .
-          zip "${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip" "$product_name"
+          zip "${{ env.product_name }}_${{ env.product_version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip" "$product_name"
       - name: Upload product artifact.
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          path: example/${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          name: ${{ env.product_name }}_${{ env.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          path: example/${{ env.product_name }}_${{ env.product_version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          name: ${{ env.product_name }}_${{ env.product_version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           if-no-files-found: error
 
   build-linux-image:
@@ -69,18 +69,18 @@ jobs:
         # For real usages, you will reference the action like this:
         # 'uses: hashicorp/actions-docker-build@v1'
         with:
-          version: 1.0.0
+          version: ${{env.product_version}}
           target: default
           arch: ${{ matrix.arch }}
           # Production tags. (These are the tags used for the multi-arch images
           # we eventually push, they must never be architecture/platform-specific.)
           tags: |
-            docker.io/hashicorp/${{env.product_name}}:${{env.version}}
-            public.ecr.aws/hashicorp/${{env.product_name}}:${{env.version}}
+            docker.io/hashicorp/${{env.product_name}}:${{env.product_version}}
+            public.ecr.aws/hashicorp/${{env.product_name}}:${{env.product_version}}
           # Dev tags are pushed more frequently by downstream processes. They also
           # must not reference the architecture.
           dev_tags: |
-            docker.io/hashicorppreview/${{env.product_name}}:${{env.version}}-dev
+            docker.io/hashicorppreview/${{env.product_name}}:${{env.product_version}}-dev
           # Usually you wouldn't need to set workdir, but this is just an example.
           workdir: example/
 
@@ -102,18 +102,18 @@ jobs:
         # For real usages, you will reference the action like this:
         # 'uses: hashicorp/actions-docker-build@v1'
         with:
-          version: 1.0.0
+          version: ${{env.product_version}}
           target: default
           arch: ${{ matrix.arch }}
           # Production tags. (These are the tags used for the multi-arch images
           # we eventually push, they need not be architecture/platform-specific.)
           tags: |
-            docker.io/hashicorp/${{env.product_name}}:${{env.version}}
-            public.ecr.aws/hashicorp/${{env.product_name}}:${{env.version}}
+            docker.io/hashicorp/${{env.product_name}}:${{env.product_version}}
+            public.ecr.aws/hashicorp/${{env.product_name}}:${{env.product_version}}
           # Dev tags are pushed more frequently by downstream processes. They also
           # need not reference the architecture.
           dev_tags: |
-            docker.io/hashicorppreview/${{env.product_name}}:${{env.version}}-dev
+            docker.io/hashicorppreview/${{env.product_name}}:${{env.product_version}}-dev
           # Usually you wouldn't need to set workdir, but this is just an example.
           workdir: example/
           Dockerfile: ${{matrix.Dockerfile}}

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -105,6 +105,8 @@ jobs:
           version: ${{env.product_version}}
           target: default
           arch: ${{ matrix.arch }}
+          # Go's -output flag during build doesn't auto-add .exe for windows, so we'll just ignore it here.
+          bin_name: actions-docker-build
           # Production tags. (These are the tags used for the multi-arch images
           # we eventually push, they need not be architecture/platform-specific.)
           tags: |

--- a/example/Dockerfile.windows-2019
+++ b/example/Dockerfile.windows-2019
@@ -1,0 +1,17 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2019 AS default
+LABEL maintainer="Team RelEng <team-rel-eng@hashicorp.com>"
+ARG PRODUCT_VERSION
+ARG PRODUCT_REVISION
+LABEL version=$PRODUCT_VERSION
+LABEL revision=$PRODUCT_REVISION
+# TARGETOS and TARGETARCH are set automatically when --platform is provided.
+ARG TARGETOS
+ARG TARGETARCH
+ARG BIN_NAME
+
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
+
+CMD ["/bin/$BIN_NAME", "default"]

--- a/example/Dockerfile.windows-2022
+++ b/example/Dockerfile.windows-2022
@@ -1,0 +1,17 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022 AS default
+LABEL maintainer="Team RelEng <team-rel-eng@hashicorp.com>"
+ARG PRODUCT_VERSION
+ARG PRODUCT_REVISION
+LABEL version=$PRODUCT_VERSION
+LABEL revision=$PRODUCT_REVISION
+# TARGETOS and TARGETARCH are set automatically when --platform is provided.
+ARG TARGETOS
+ARG TARGETARCH
+ARG BIN_NAME
+
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
+
+CMD ["/bin/$BIN_NAME", "default"]


### PR DESCRIPTION
This also allows us to exercise the windows builds as CI

### Justification

Recent windows build support was added, but the example did not demo it's use. Since example also couples as a CI test. We should add it.

### Summary

Adds windows container builds for both 2022 and 2019. Since windows images are specific to their Hosts, it's important we demo producing both.

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [x] New or updated tests which validate the new behavior.  _(Thank you!)_

Resubmit of #75, where it was on a fork.