### PR TITLE
Update Artifact Actions to use > v4.0.0

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -46,7 +46,6 @@ jobs:
           path: example/${{ env.product_name }}_${{ env.product_version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           name: ${{ env.product_name }}_${{ env.product_version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           if-no-files-found: error
-          overwrite: true
 
   build-linux-image:
     needs:

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -41,11 +41,12 @@ jobs:
           go build -o "$product_name" .
           zip "${{ env.product_name }}_${{ env.product_version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip" "$product_name"
       - name: Upload product artifact.
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           path: example/${{ env.product_name }}_${{ env.product_version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           name: ${{ env.product_name }}_${{ env.product_version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           if-no-files-found: error
+          overwrite: true
 
   build-linux-image:
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -272,7 +272,7 @@ jobs:
         with:
           version: 1.0.0
           target: default
-          arch: amd64
+          arch: arm64
           do_zip_extract_step: false
           workdir: ./my-context-dir
           tags: ${{env.TAG_PREFIX}}/action-test-dockerfile-in-root:tag1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,13 +37,11 @@ jobs:
         with:
           path: testdata/test_bin.zip
           name: test_bin.zip
-          overwrite: true
       - name: Upload a test artifact.
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           path: testdata/actions-docker-build.zip
           name: actions-docker-build.zip
-          overwrite: true
 
   action-test-dockerfile-in-root:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,15 +33,17 @@ jobs:
           zip ./testdata/test_bin.zip ./testdata/test_bin
           zip ./testdata/actions-docker-build.zip ./testdata/actions-docker-build
       - name: Upload a test artifact.
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           path: testdata/test_bin.zip
           name: test_bin.zip
+          overwrite: true
       - name: Upload a test artifact.
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           path: testdata/actions-docker-build.zip
           name: actions-docker-build.zip
+          overwrite: true
 
   action-test-dockerfile-in-root:
     runs-on: ubuntu-latest
@@ -252,7 +254,7 @@ jobs:
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       # Handle the artifact download ourselves
       - name: Download Product Zip Artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
           path: archive
           name: actions-docker-build.zip

--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
       run: $GITHUB_ACTION_PATH/scripts/register_qemu_binfmt
 
     - name: Download Product Zip Artifact
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
       if: ${{ inputs.do_zip_extract_step == 'true'  }}
       with:
         path: ${{ env.ZIP_LOCATION }}
@@ -212,7 +212,7 @@ runs:
       run: $GITHUB_ACTION_PATH/scripts/create_metadata
 
     - name: Upload Docker Image metadata
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       env:
         # Add _redhat if this is a redhat call.
         REDHAT_SUFFIX: ${{ inputs.redhat_tag && '_redhat' || '' }}
@@ -220,27 +220,31 @@ runs:
         name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.json
         path: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.json
         if-no-files-found: error
+        overwrite: true
 
     - name: Upload Prod Tarball
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       if: ${{ env.TAGS != '' }}
       with:
         name: ${{ env.TARBALL_NAME }}
         path: ${{ env.TARBALL_NAME }}
         if-no-files-found: error
+        overwrite: true
 
     - name: Upload Dev Tarball
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       if: ${{ env.DEV_TAGS != '' }}
       with:
         name: ${{ env.DEV_TARBALL_NAME }}
         path: ${{ env.DEV_TARBALL_NAME }}
         if-no-files-found: error
+        overwrite: true
 
     - name: Upload Red Hat Tarball
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       if: ${{ env.REDHAT_TAG != '' }}
       with:
         name: ${{ env.REDHAT_TARBALL_NAME }}
         path: ${{ env.REDHAT_TARBALL_NAME }}
         if-no-files-found: error
+        overwrite: true

--- a/action.yml
+++ b/action.yml
@@ -223,7 +223,7 @@ runs:
       env:
         # Add _redhat if this is a redhat call.
         REDHAT_SUFFIX: ${{ inputs.redhat_tag && '_redhat' || '' }}
-        RANDOM: "${{ env.RANDOM_STRING }}"
+        RANDOM_STRING: "${{ env.RANDOM_STRING }}"
       with:
         name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.${{ inputs.arch }}.${{ env.RANDOM_STRING }}.json
         path: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.${{ inputs.arch }}.${{ env.RANDOM_STRING }}.json

--- a/action.yml
+++ b/action.yml
@@ -207,8 +207,15 @@ runs:
       env:
         IMAGE_NAME: ${{env.AUTO_TAG}}
 
+    - name: Generate Random String to use for tag list json
+      shell: bash
+      run: |
+        echo "RANDOM_STRING=$(echo $((2000 + $RANDOM % 40000)))" >> $GITHUB_ENV
+
     - name: Generate Docker metadata
       shell: bash
+      env:
+        RANDOM_STRING: "${{ env.RANDOM_STRING }}"
       run: $GITHUB_ACTION_PATH/scripts/create_metadata
 
     - name: Upload Docker Image metadata
@@ -216,11 +223,11 @@ runs:
       env:
         # Add _redhat if this is a redhat call.
         REDHAT_SUFFIX: ${{ inputs.redhat_tag && '_redhat' || '' }}
+        RANDOM: "${{ env.RANDOM_STRING }}"
       with:
-        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.json
-        path: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.json
+        name: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.${{ inputs.arch }}.${{ env.RANDOM_STRING }}.json
+        path: docker_tag_list_${{env.TARGET}}${{env.REDHAT_SUFFIX}}.${{ inputs.arch }}.${{ env.RANDOM_STRING }}.json
         if-no-files-found: error
-        overwrite: true
 
     - name: Upload Prod Tarball
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
@@ -229,7 +236,6 @@ runs:
         name: ${{ env.TARBALL_NAME }}
         path: ${{ env.TARBALL_NAME }}
         if-no-files-found: error
-        overwrite: true
 
     - name: Upload Dev Tarball
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
@@ -238,7 +244,6 @@ runs:
         name: ${{ env.DEV_TARBALL_NAME }}
         path: ${{ env.DEV_TARBALL_NAME }}
         if-no-files-found: error
-        overwrite: true
 
     - name: Upload Red Hat Tarball
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
@@ -247,4 +252,3 @@ runs:
         name: ${{ env.REDHAT_TARBALL_NAME }}
         path: ${{ env.REDHAT_TARBALL_NAME }}
         if-no-files-found: error
-        overwrite: true

--- a/scripts/create_metadata
+++ b/scripts/create_metadata
@@ -7,11 +7,11 @@ set -Eeuo pipefail
 OUT_DIR="${OUT_DIR:-.}"
 
 FILE_SUFFIX=""
-if [ -n "${REDHAT_TAG:-}" ]; then 
+if [ -n "${REDHAT_TAG:-}" ]; then
 	FILE_SUFFIX="_redhat"
 fi
 
-OUT_FILE="docker_tag_list_${TARGET:?}${FILE_SUFFIX}.json"
+OUT_FILE="docker_tag_list_${TARGET:?}${FILE_SUFFIX}.${ARCH}.${RANDOM_STRING}.json"
 
 OUT_PATH="${OUT_DIR}/${OUT_FILE}"
 

--- a/scripts/create_metadata.bats
+++ b/scripts/create_metadata.bats
@@ -41,7 +41,11 @@ assert_file_contains_json() { local FILEPATH="$1"; local JSON="$2"
 
 	export TARGET="target1"
 
-	WANT_FILENAME="docker_tag_list_target1.json"
+	export ARCH="arch1"
+
+	export RANDOM_STRING="12345"
+
+	WANT_FILENAME="docker_tag_list_target1.arch1.12345.json"
 	WANT_FILEPATH="$OUT_DIR/$WANT_FILENAME"
 
 	WANT_JSON='{
@@ -75,7 +79,11 @@ assert_file_contains_json() { local FILEPATH="$1"; local JSON="$2"
 
 	export TARGET="target1"
 
-	WANT_FILENAME="docker_tag_list_target1.json"
+	export ARCH="arch1"
+
+	export RANDOM_STRING=12345
+
+	WANT_FILENAME="docker_tag_list_target1.arch1.12345.json"
 	WANT_FILEPATH="$OUT_DIR/$WANT_FILENAME"
 
 	WANT_JSON='{


### PR DESCRIPTION
### Justification

[update actions/download-artifact used by hashicorp/actions-docker-build](https://github.com/hashicorp/releng-support/issues/298)

### Summary

- The current major version v3 of the artifact upload/download actions uses a deprecated version of NodeJS (v16). This commit updates the artifact actions to use v4 which includes a supported version of NodeJS (v20).

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [X] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_