### PR TITLE
Pull from platform independent tag

### DIFF
--- a/scripts/register_qemu_binfmt
+++ b/scripts/register_qemu_binfmt
@@ -6,4 +6,4 @@ echo "==> Registering qemu into /proc/sys/fs/binfmt_misc"
 docker run --pull always \
            --privileged \
            --rm \
-           docker.mirror.hashicorp.services/tonistiigi/binfmt@sha256:5540f38542290735d17da57d7084f684c62336105d018c605058daf03e4c8256 --install all
+           docker.mirror.hashicorp.services/tonistiigi/binfmt:qemu-v6.1.0-21 --install all


### PR DESCRIPTION
### Justification

https://hashicorp.atlassian.net/browse/VAULT-29297

### Summary

The tagged SHA is only for AMD docker image, however to support ARM docker images this needs to be updated.

- [ ] Once released, revert the tag changes [here](https://github.com/hashicorp/vault-enterprise/pull/6322)