### PR TITLE
update: make releasing and tagging more clear if vX tag already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,20 +398,27 @@ so that they receive upgrades automatically. In order to do this:
 Locally fetch the new tag created by the release:
 
 ```
-git fetch vX.Y.Z
+git fetch origin vX.Y.Z (i.e. v2.2.0)
 ```
 
-Add the new tags
+If the `vX` tag does not exist, then proceed with the below: 
 
 ```
 git tag -f vX.Y vX.Y.Z
 git tag -f vX vX.Y.Z
 ```
-
 Push the new tags
 
 ```
 git push origin vX.Y vX
 ```
 
-And you're all done!
+If the `vX` (i.e. v2) tag already exists, you will need to delete it and repoint the major version to it: 
+```
+git tag -d vX
+git tag -f vX vX.Y.Z 
+```
+Update the major version tag upstream
+```
+git push origin :refs/tags/vX && git push origin vX
+```


### PR DESCRIPTION
### Summary

When a tag that goes by the format of `vX` i.e. `v2` exists, the release instructions aren't explicitly clear that we will need to _delete_ the tag and then repoint it to the major version. This PR updates the instructions in the README to be more clearer. 

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [x] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_