### PR TITLE
Replace 2019 runner with 2025 runner

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -91,7 +91,7 @@ jobs:
       matrix:
         include:
           - { runner: "windows-2022", arch: "amd64", Dockerfile: "Dockerfile.windows-2022" }
-          - { runner: "windows-2019", arch: "amd64", Dockerfile: "Dockerfile.windows-2019" }
+          - { runner: "windows-2025", arch: "amd64", Dockerfile: "Dockerfile.windows-2025" }
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout

--- a/example/Dockerfile.windows-2025
+++ b/example/Dockerfile.windows-2025
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 # syntax=docker/dockerfile:1
-FROM mcr.microsoft.com/windows/nanoserver:ltsc2019 AS default
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2025 AS default
 LABEL maintainer="Team RelEng <team-rel-eng@hashicorp.com>"
 ARG PRODUCT_VERSION
 ARG PRODUCT_REVISION


### PR DESCRIPTION
### Justification

The windows 2019 runner image has been removed, tests using it now fail.
https://github.com/actions/runner-images/issues/12045

### Summary

Replace the 2019 image with a 2025 image.

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [X] No new or changed behavior.